### PR TITLE
fix!: remove `xcAssets` key and replace the data to fit in each parachains key under their relay chain

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -82,7 +82,126 @@
       "assetsInfo": {},
       "foreignAssetsInfo": {},
       "poolPairsInfo": {},
-      "specName": "acala"
+      "specName": "acala",
+      "xcAssetsData": [
+        {
+          "paraID": 1000,
+          "symbol": "USDT",
+          "decimals": 6,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+          "asset": {
+            "ForeignAsset": "12"
+          }
+        },
+        {
+          "paraID": 1000,
+          "symbol": "WETH",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":100}]}}}",
+          "asset": {
+            "ForeignAsset": "6"
+          }
+        },
+        {
+          "paraID": 1000,
+          "symbol": "WBTC",
+          "decimals": 8,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":21}]}}}",
+          "asset": {
+            "ForeignAsset": "5"
+          }
+        },
+        {
+          "paraID": 2004,
+          "symbol": "GLMR",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2004},{\"palletInstance\":10}]}}}",
+          "asset": {
+            "ForeignAsset": "0"
+          }
+        },
+        {
+          "paraID": 2006,
+          "symbol": "ASTR",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2006}}}}",
+          "asset": {
+            "ForeignAsset": "2"
+          }
+        },
+        {
+          "paraID": 2008,
+          "symbol": "CRU",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2008}}}}",
+          "asset": {
+            "ForeignAsset": "11"
+          }
+        },
+        {
+          "paraID": 2011,
+          "symbol": "EQD",
+          "decimals": 9,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2011},{\"generalKey\":\"0x657164\"}]}}}",
+          "asset": {
+            "ForeignAsset": "8"
+          }
+        },
+        {
+          "paraID": 2011,
+          "symbol": "EQ",
+          "decimals": 9,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2011}}}}",
+          "asset": {
+            "ForeignAsset": "7"
+          }
+        },
+        {
+          "paraID": 2012,
+          "symbol": "PARA",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2012},{\"generalKey\":\"0x50415241\"}]}}}",
+          "asset": {
+            "ForeignAsset": "1"
+          }
+        },
+        {
+          "paraID": 2032,
+          "symbol": "IBTC",
+          "decimals": 8,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0001\"}]}}}",
+          "asset": {
+            "ForeignAsset": "3"
+          }
+        },
+        {
+          "paraID": 2032,
+          "symbol": "INTR",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0002\"}]}}}",
+          "asset": {
+            "ForeignAsset": "4"
+          }
+        },
+        {
+          "paraID": 2035,
+          "symbol": "PHA",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2035}}}}",
+          "asset": {
+            "ForeignAsset": "9"
+          }
+        },
+        {
+          "paraID": 2037,
+          "symbol": "UNQ",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2037}}}}",
+          "asset": {
+            "ForeignAsset": "10"
+          }
+        }
+      ]
     },
     "2002": {
       "tokens": [
@@ -91,7 +210,23 @@
       "assetsInfo": {},
       "foreignAssetsInfo": {},
       "poolPairsInfo": {},
-      "specName": "clover-mainnet"
+      "specName": "clover-mainnet",
+      "xcAssetsData": [
+        {
+          "paraID": 2006,
+          "symbol": "ASTR",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2006}}}}",
+          "asset": "12"
+        },
+        {
+          "paraID": 2012,
+          "symbol": "PARA",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2012},{\"generalKey\":\"0x50415241\"}]}}}",
+          "asset": "11"
+        }
+      ]
     },
     "2004": {
       "tokens": [
@@ -100,7 +235,163 @@
       "assetsInfo": {},
       "foreignAssetsInfo": {},
       "poolPairsInfo": {},
-      "specName": "moonbeam"
+      "specName": "moonbeam",
+      "xcAssetsData": [
+        {
+          "paraID": 0,
+          "symbol": "DOT",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
+          "asset": "42259045809535163221576417993425387648"
+        },
+        {
+          "paraID": 1000,
+          "symbol": "USDT",
+          "decimals": 6,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+          "asset": "311091173110107856861649819128533077277"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "aUSD",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0001\"}]}}}",
+          "asset": "110021739665376159354538090254163045594"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "ACA",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0000\"}]}}}",
+          "asset": "224821240862170613278369189818311486111"
+        },
+        {
+          "paraID": 2006,
+          "symbol": "ASTR",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2006}}}}",
+          "asset": "224077081838586484055667086558292981199"
+        },
+        {
+          "paraID": 2011,
+          "symbol": "EQD",
+          "decimals": 9,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2011},{\"generalKey\":\"0x657164\"}]}}}",
+          "asset": "187224307232923873519830480073807488153"
+        },
+        {
+          "paraID": 2011,
+          "symbol": "EQ",
+          "decimals": 9,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2011}}}}",
+          "asset": "190590555344745888270686124937537713878"
+        },
+        {
+          "paraID": 2012,
+          "symbol": "PARA",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2012},{\"generalKey\":\"0x50415241\"}]}}}",
+          "asset": "32615670524745285411807346420584982855"
+        },
+        {
+          "paraID": 2026,
+          "symbol": "NODL",
+          "decimals": 11,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2026},{\"palletInstance\":2}]}}}",
+          "asset": "309163521958167876851250718453738106865"
+        },
+        {
+          "paraID": 2030,
+          "symbol": "FIL",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0804\"}]}}}",
+          "asset": "144012926827374458669278577633504620722"
+        },
+        {
+          "paraID": 2030,
+          "symbol": "vDOT",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0900\"}]}}}",
+          "asset": "29085784439601774464560083082574142143"
+        },
+        {
+          "paraID": 2030,
+          "symbol": "vGLMR",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0901\"}]}}}",
+          "asset": "204507659831918931608354793288110796652"
+        },
+        {
+          "paraID": 2030,
+          "symbol": "BNC",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0001\"}]}}}",
+          "asset": "165823357460190568952172802245839421906"
+        },
+        {
+          "paraID": 2030,
+          "symbol": "vFIL",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0904\"}]}}}",
+          "asset": "272547899416482196831721420898811311297"
+        },
+        {
+          "paraID": 2031,
+          "symbol": "CFG",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2031},{\"generalKey\":\"0x0001\"}]}}}",
+          "asset": "91372035960551235635465443179559840483"
+        },
+        {
+          "paraID": 2032,
+          "symbol": "IBTC",
+          "decimals": 8,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0001\"}]}}}",
+          "asset": "120637696315203257380661607956669368914"
+        },
+        {
+          "paraID": 2032,
+          "symbol": "INTR",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0002\"}]}}}",
+          "asset": "101170542313601871197860408087030232491"
+        },
+        {
+          "paraID": 2034,
+          "symbol": "HDX",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2034},{\"generalIndex\":0}]}}}",
+          "asset": "69606720909260275826784788104880799692"
+        },
+        {
+          "paraID": 2035,
+          "symbol": "PHA",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2035}}}}",
+          "asset": "132685552157663328694213725410064821485"
+        },
+        {
+          "paraID": 2046,
+          "symbol": "RING",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2046},{\"palletInstance\":5}]}}}",
+          "asset": "125699734534028342599692732320197985871"
+        },
+        {
+          "paraID": 2101,
+          "symbol": "SUB",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2101}}}}",
+          "asset": "89994634370519791027168048838578580624"
+        },
+        {
+          "paraID": 2104,
+          "symbol": "MANTA",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2104}}}}",
+          "asset": "166446646689194205559791995948102903873"
+        }
+      ]
     },
     "2006": {
       "tokens": [
@@ -109,7 +400,135 @@
       "assetsInfo": {},
       "foreignAssetsInfo": {},
       "poolPairsInfo": {},
-      "specName": "astar"
+      "specName": "astar",
+      "xcAssetsData": [
+        {
+          "paraID": 0,
+          "symbol": "DOT",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
+          "asset": "340282366920938463463374607431768211455"
+        },
+        {
+          "paraID": 1000,
+          "symbol": "USDT",
+          "decimals": 6,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+          "asset": "4294969280"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "LDOT",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0003\"}]}}}",
+          "asset": "18446744073709551618"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "ACA",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0000\"}]}}}",
+          "asset": "18446744073709551616"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "aSEED",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0001\"}]}}}",
+          "asset": "18446744073709551617"
+        },
+        {
+          "paraID": 2002,
+          "symbol": "CLV",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2002}}}}",
+          "asset": "18446744073709551625"
+        },
+        {
+          "paraID": 2004,
+          "symbol": "GLMR",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2004},{\"palletInstance\":10}]}}}",
+          "asset": "18446744073709551619"
+        },
+        {
+          "paraID": 2011,
+          "symbol": "EQD",
+          "decimals": 9,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2011},{\"generalKey\":\"0x657164\"}]}}}",
+          "asset": "18446744073709551629"
+        },
+        {
+          "paraID": 2011,
+          "symbol": "EQ",
+          "decimals": 9,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2011}}}}",
+          "asset": "18446744073709551628"
+        },
+        {
+          "paraID": 2030,
+          "symbol": "vsDOT",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0403\"}]}}}",
+          "asset": "18446744073709551626"
+        },
+        {
+          "paraID": 2030,
+          "symbol": "vDOT",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0900\"}]}}}",
+          "asset": "18446744073709551624"
+        },
+        {
+          "paraID": 2030,
+          "symbol": "BNC",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0001\"}]}}}",
+          "asset": "18446744073709551623"
+        },
+        {
+          "paraID": 2032,
+          "symbol": "IBTC",
+          "decimals": 8,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0001\"}]}}}",
+          "asset": "18446744073709551620"
+        },
+        {
+          "paraID": 2032,
+          "symbol": "INTR",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0002\"}]}}}",
+          "asset": "18446744073709551621"
+        },
+        {
+          "paraID": 2034,
+          "symbol": "HDX",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2034},{\"generalIndex\":0}]}}}",
+          "asset": "18446744073709551630"
+        },
+        {
+          "paraID": 2035,
+          "symbol": "PHA",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2035}}}}",
+          "asset": "18446744073709551622"
+        },
+        {
+          "paraID": 2037,
+          "symbol": "UNQ",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2037}}}}",
+          "asset": "18446744073709551631"
+        },
+        {
+          "paraID": 2046,
+          "symbol": "RING",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2046},{\"palletInstance\":5}]}}}",
+          "asset": "18446744073709551627"
+        }
+      ]
     },
     "2007": {
       "tokens": [
@@ -145,7 +564,121 @@
       "assetsInfo": {},
       "foreignAssetsInfo": {},
       "poolPairsInfo": {},
-      "specName": "parallel"
+      "specName": "parallel",
+      "xcAssetsData": [
+        {
+          "paraID": 0,
+          "symbol": "DOT",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
+          "asset": "101"
+        },
+        {
+          "paraID": 1000,
+          "symbol": "USDT",
+          "decimals": 6,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+          "asset": "102"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "ACA",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0000\"}]}}}",
+          "asset": "108"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "LDOT",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0003\"}]}}}",
+          "asset": "110"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "lcDOT",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x040d000000\"}]}}}",
+          "asset": "106"
+        },
+        {
+          "paraID": 2002,
+          "symbol": "CLV",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2002}}}}",
+          "asset": "130"
+        },
+        {
+          "paraID": 2004,
+          "symbol": "GLMR",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2004},{\"palletInstance\":10}]}}}",
+          "asset": "114"
+        },
+        {
+          "paraID": 2012,
+          "symbol": "sDOT",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2012},{\"generalKey\":\"0x73444f54\"}]}}}",
+          "asset": "1001"
+        },
+        {
+          "paraID": 2012,
+          "symbol": "cDOT-8/15",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2012},{\"palletInstance\":6},{\"generalIndex\":200080015}]}}}",
+          "asset": "200080015"
+        },
+        {
+          "paraID": 2012,
+          "symbol": "cDOT-9/16",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2012},{\"palletInstance\":6},{\"generalIndex\":200090016}]}}}",
+          "asset": "200090016"
+        },
+        {
+          "paraID": 2012,
+          "symbol": "cDOT-6/13",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2012},{\"palletInstance\":6},{\"generalIndex\":200060013}]}}}",
+          "asset": "200060013"
+        },
+        {
+          "paraID": 2012,
+          "symbol": "cDOT-10/17",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2012},{\"palletInstance\":6},{\"generalIndex\":200100017}]}}}",
+          "asset": "200100017"
+        },
+        {
+          "paraID": 2012,
+          "symbol": "cDOT-7/14",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2012},{\"palletInstance\":6},{\"generalIndex\":200070014}]}}}",
+          "asset": "200070014"
+        },
+        {
+          "paraID": 2032,
+          "symbol": "IBTC",
+          "decimals": 8,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0001\"}]}}}",
+          "asset": "122"
+        },
+        {
+          "paraID": 2032,
+          "symbol": "INTR",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0002\"}]}}}",
+          "asset": "120"
+        },
+        {
+          "paraID": 2035,
+          "symbol": "PHA",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2035}}}}",
+          "asset": "115"
+        }
+      ]
     },
     "2013": {
       "tokens": [
@@ -181,7 +714,90 @@
       "assetsInfo": {},
       "foreignAssetsInfo": {},
       "poolPairsInfo": {},
-      "specName": "bifrost_polkadot"
+      "specName": "bifrost_polkadot",
+      "xcAssetsData": [
+        {
+          "paraID": 0,
+          "symbol": "DOT",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
+          "asset": {
+            "Token2": "0"
+          }
+        },
+        {
+          "paraID": 1000,
+          "symbol": "USDT",
+          "decimals": 6,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+          "asset": {
+            "Token2": "2"
+          }
+        },
+        {
+          "paraID": 2004,
+          "symbol": "GLMR",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2004},{\"palletInstance\":10}]}}}",
+          "asset": {
+            "Token2": "1"
+          }
+        },
+        {
+          "paraID": 2006,
+          "symbol": "ASTR",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2006}}}}",
+          "asset": {
+            "Token2": "3"
+          }
+        },
+        {
+          "paraID": 2030,
+          "symbol": "vGLMR",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0901\"}]}}}",
+          "asset": {
+            "VToken2": "1"
+          }
+        },
+        {
+          "paraID": 2030,
+          "symbol": "vFIL",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0904\"}]}}}",
+          "asset": {
+            "VToken2": "4"
+          }
+        },
+        {
+          "paraID": 2030,
+          "symbol": "FIL",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0804\"}]}}}",
+          "asset": {
+            "Token2": "4"
+          }
+        },
+        {
+          "paraID": 2030,
+          "symbol": "vDOT",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0900\"}]}}}",
+          "asset": {
+            "VToken2": "0"
+          }
+        },
+        {
+          "paraID": 2030,
+          "symbol": "vsDOT",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0403\"}]}}}",
+          "asset": {
+            "VSToken2": "0"
+          }
+        }
+      ]
     },
     "2031": {
       "tokens": [
@@ -190,7 +806,61 @@
       "assetsInfo": {},
       "foreignAssetsInfo": {},
       "poolPairsInfo": {},
-      "specName": "centrifuge"
+      "specName": "centrifuge",
+      "xcAssetsData": [
+        {
+          "paraID": 0,
+          "symbol": "DOT",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
+          "asset": {
+            "ForeignAsset": "5"
+          }
+        },
+        {
+          "paraID": 1000,
+          "symbol": "USDT",
+          "decimals": 6,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+          "asset": {
+            "ForeignAsset": "1"
+          }
+        },
+        {
+          "paraID": 1000,
+          "symbol": "USDC",
+          "decimals": 6,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1337}]}}}",
+          "asset": {
+            "ForeignAsset": "6"
+          }
+        },
+        {
+          "paraID": 2000,
+          "symbol": "aUSD",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0001\"}]}}}",
+          "asset": {
+            "ForeignAsset": "3"
+          }
+        },
+        {
+          "paraID": 2004,
+          "symbol": "GLMR",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2004},{\"palletInstance\":10}]}}}",
+          "asset": {
+            "ForeignAsset": "4"
+          }
+        },
+        {
+          "paraID": 2031,
+          "symbol": "CFG",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2031},{\"generalKey\":\"0x0001\"}]}}}",
+          "asset": "Native"
+        }
+      ]
     },
     "2032": {
       "tokens": [
@@ -204,7 +874,27 @@
       "assetsInfo": {},
       "foreignAssetsInfo": {},
       "poolPairsInfo": {},
-      "specName": "interlay-parachain"
+      "specName": "interlay-parachain",
+      "xcAssetsData": [
+        {
+          "paraID": 1000,
+          "symbol": "USDT",
+          "decimals": 6,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+          "asset": {
+            "ForeignAsset": "2"
+          }
+        },
+        {
+          "paraID": 2000,
+          "symbol": "LDOT",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0003\"}]}}}",
+          "asset": {
+            "ForeignAsset": "1"
+          }
+        }
+      ]
     },
     "2034": {
       "tokens": [
@@ -213,7 +903,149 @@
       "assetsInfo": {},
       "foreignAssetsInfo": {},
       "poolPairsInfo": {},
-      "specName": "hydradx"
+      "specName": "hydradx",
+      "xcAssetsData": [
+        {
+          "paraID": 0,
+          "symbol": "DOT",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
+          "asset": "5"
+        },
+        {
+          "paraID": 1000,
+          "symbol": "USDT",
+          "decimals": 6,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+          "asset": "10"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "USDC",
+          "decimals": 6,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0207df96d1341a7d16ba1ad431e2c847d978bc2bce\"}]}}}",
+          "asset": "7"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "DAI",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0254a37a01cd75b616d63e0ab665bffdb0143c52ae\"}]}}}",
+          "asset": "2"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "APE",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x02f4c723e61709d90f89939c1852f516e373d418a8\"}]}}}",
+          "asset": "6"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "WBTC",
+          "decimals": 8,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x02c80084af223c8b598536178d9361dc55bfda6818\"}]}}}",
+          "asset": "3"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "WETH",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x025a4d6acdc4e3e5ab15717f407afe957f7a242578\"}]}}}",
+          "asset": "4"
+        },
+        {
+          "paraID": 2004,
+          "symbol": "WETH",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2004},{\"palletInstance\":110},{\"accountKey20\":{\"network\":null,\"key\":\"0xab3f0245b83feb11d15aaffefd7ad465a59817ed\"}}]}}}",
+          "asset": "20"
+        },
+        {
+          "paraID": 2004,
+          "symbol": "WBTC",
+          "decimals": 8,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2004},{\"palletInstance\":110},{\"accountKey20\":{\"network\":null,\"key\":\"0xe57ebd2d67b462e9926e04a8e33f01cd0d64346d\"}}]}}}",
+          "asset": "19"
+        },
+        {
+          "paraID": 2004,
+          "symbol": "GLMR",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2004},{\"palletInstance\":10}]}}}",
+          "asset": "16"
+        },
+        {
+          "paraID": 2004,
+          "symbol": "USDC",
+          "decimals": 6,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2004},{\"palletInstance\":110},{\"accountKey20\":{\"network\":null,\"key\":\"0x931715fee2d06333043d11f658c8ce934ac61d0c\"}}]}}}",
+          "asset": "21"
+        },
+        {
+          "paraID": 2004,
+          "symbol": "DAI",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2004},{\"palletInstance\":110},{\"accountKey20\":{\"network\":null,\"key\":\"0x06e605775296e851ff43b4daa541bb0984e9d6fd\"}}]}}}",
+          "asset": "18"
+        },
+        {
+          "paraID": 2006,
+          "symbol": "ASTR",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2006}}}}",
+          "asset": "9"
+        },
+        {
+          "paraID": 2030,
+          "symbol": "BNC",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0001\"}]}}}",
+          "asset": "14"
+        },
+        {
+          "paraID": 2030,
+          "symbol": "vDOT",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0900\"}]}}}",
+          "asset": "15"
+        },
+        {
+          "paraID": 2031,
+          "symbol": "CFG",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2031},{\"generalKey\":\"0x0001\"}]}}}",
+          "asset": "13"
+        },
+        {
+          "paraID": 2032,
+          "symbol": "iBTC",
+          "decimals": 8,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0001\"}]}}}",
+          "asset": "11"
+        },
+        {
+          "paraID": 2032,
+          "symbol": "INTR",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0002\"}]}}}",
+          "asset": "17"
+        },
+        {
+          "paraID": 2035,
+          "symbol": "PHA",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2035}}}}",
+          "asset": "8"
+        },
+        {
+          "paraID": 2092,
+          "symbol": "ZTG",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2092},{\"generalKey\":\"0x0001\"}]}}}",
+          "asset": "12"
+        }
+      ]
     },
     "2035": {
       "tokens": [
@@ -222,7 +1054,93 @@
       "assetsInfo": {},
       "foreignAssetsInfo": {},
       "poolPairsInfo": {},
-      "specName": "phala"
+      "specName": "phala",
+      "xcAssetsData": [
+        {
+          "paraID": 0,
+          "symbol": "DOT",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
+          "asset": "0"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "ACA",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0000\"}]}}}",
+          "asset": "5"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "AUSD",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0001\"}]}}}",
+          "asset": "3"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "LDOT",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0003\"}]}}}",
+          "asset": "4"
+        },
+        {
+          "paraID": 2004,
+          "symbol": "GLMR",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2004},{\"palletInstance\":10}]}}}",
+          "asset": "1"
+        },
+        {
+          "paraID": 2006,
+          "symbol": "ASTR",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2006}}}}",
+          "asset": "6"
+        },
+        {
+          "paraID": 2011,
+          "symbol": "EQ",
+          "decimals": 9,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2011}}}}",
+          "asset": "9"
+        },
+        {
+          "paraID": 2011,
+          "symbol": "EQD",
+          "decimals": 9,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2011},{\"generalKey\":\"0x657164\"}]}}}",
+          "asset": "10"
+        },
+        {
+          "paraID": 2012,
+          "symbol": "PARA",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2012},{\"generalKey\":\"0x50415241\"}]}}}",
+          "asset": "2"
+        },
+        {
+          "paraID": 2030,
+          "symbol": "BNC",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0001\"}]}}}",
+          "asset": "8"
+        },
+        {
+          "paraID": 2034,
+          "symbol": "HDX",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2034},{\"generalIndex\":0}]}}}",
+          "asset": "11"
+        },
+        {
+          "paraID": 2046,
+          "symbol": "RING",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2046},{\"palletInstance\":5}]}}}",
+          "asset": "7"
+        }
+      ]
     },
     "2037": {
       "tokens": [
@@ -258,7 +1176,16 @@
       "assetsInfo": {},
       "foreignAssetsInfo": {},
       "poolPairsInfo": {},
-      "specName": "origintrail-parachain"
+      "specName": "origintrail-parachain",
+      "xcAssetsData": [
+        {
+          "paraID": 2043,
+          "symbol": "TRAC",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2043},{\"generalIndex\":1}]}}}",
+          "asset": "1"
+        }
+      ]
     },
     "2046": {
       "tokens": [
@@ -598,7 +1525,198 @@
       "assetsInfo": {},
       "foreignAssetsInfo": {},
       "poolPairsInfo": {},
-      "specName": "karura"
+      "specName": "karura",
+      "xcAssetsData": [
+        {
+          "paraID": 1000,
+          "symbol": "RMRK",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":8}]}}}",
+          "asset": {
+            "ForeignAsset": "0"
+          }
+        },
+        {
+          "paraID": 1000,
+          "symbol": "USDT",
+          "decimals": 6,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+          "asset": {
+            "ForeignAsset": "7"
+          }
+        },
+        {
+          "paraID": 1000,
+          "symbol": "ARIS",
+          "decimals": 8,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":16}]}}}",
+          "asset": {
+            "ForeignAsset": "1"
+          }
+        },
+        {
+          "paraID": 2007,
+          "symbol": "SDN",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2007}}}}",
+          "asset": {
+            "ForeignAsset": "18"
+          }
+        },
+        {
+          "paraID": 2012,
+          "symbol": "CSM",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2012}}}}",
+          "asset": {
+            "ForeignAsset": "5"
+          }
+        },
+        {
+          "paraID": 2015,
+          "symbol": "TEER",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2015},{\"generalKey\":\"0x54454552\"}]}}}",
+          "asset": {
+            "ForeignAsset": "8"
+          }
+        },
+        {
+          "paraID": 2023,
+          "symbol": "MOVR",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2023},{\"palletInstance\":10}]}}}",
+          "asset": {
+            "ForeignAsset": "3"
+          }
+        },
+        {
+          "paraID": 2024,
+          "symbol": "GENS",
+          "decimals": 9,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2024}}}}",
+          "asset": {
+            "ForeignAsset": "14"
+          }
+        },
+        {
+          "paraID": 2024,
+          "symbol": "EQD",
+          "decimals": 9,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2024},{\"generalKey\":\"0x657164\"}]}}}",
+          "asset": {
+            "ForeignAsset": "15"
+          }
+        },
+        {
+          "paraID": 2084,
+          "symbol": "KMA",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2084}}}}",
+          "asset": {
+            "ForeignAsset": "10"
+          }
+        },
+        {
+          "paraID": 2085,
+          "symbol": "HKO",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2085},{\"generalKey\":\"0x484b4f\"}]}}}",
+          "asset": {
+            "ForeignAsset": "4"
+          }
+        },
+        {
+          "paraID": 2088,
+          "symbol": "AIR",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2088},{\"generalKey\":\"0x0001\"}]}}}",
+          "asset": {
+            "ForeignAsset": "12"
+          }
+        },
+        {
+          "paraID": 2090,
+          "symbol": "BSX",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2090},{\"generalIndex\":0}]}}}",
+          "asset": {
+            "ForeignAsset": "11"
+          }
+        },
+        {
+          "paraID": 2095,
+          "symbol": "QTZ",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2095}}}}",
+          "asset": {
+            "ForeignAsset": "2"
+          }
+        },
+        {
+          "paraID": 2096,
+          "symbol": "NEER",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2096},{\"generalKey\":\"0x000000000000000000\"}]}}}",
+          "asset": {
+            "ForeignAsset": "9"
+          }
+        },
+        {
+          "paraID": 2102,
+          "symbol": "PCHU",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2102},{\"generalKey\":\"0x50434855\"}]}}}",
+          "asset": {
+            "ForeignAsset": "17"
+          }
+        },
+        {
+          "paraID": 2105,
+          "symbol": "CRAB",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2105},{\"palletInstance\":5}]}}}",
+          "asset": {
+            "ForeignAsset": "13"
+          }
+        },
+        {
+          "paraID": 2106,
+          "symbol": "LIT",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2106},{\"palletInstance\":10}]}}}",
+          "asset": {
+            "ForeignAsset": "20"
+          }
+        },
+        {
+          "paraID": 2107,
+          "symbol": "KICO",
+          "decimals": 14,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2107},{\"generalKey\":\"0x4b49434f\"}]}}}",
+          "asset": {
+            "ForeignAsset": "6"
+          }
+        },
+        {
+          "paraID": 2114,
+          "symbol": "TUR",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2114}}}}",
+          "asset": {
+            "ForeignAsset": "16"
+          }
+        },
+        {
+          "paraID": 2118,
+          "symbol": "LT",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2118},{\"generalKey\":\"0x4c54\"}]}}}",
+          "asset": {
+            "ForeignAsset": "19"
+          }
+        }
+      ]
     },
     "2001": {
       "tokens": [
@@ -615,7 +1733,162 @@
       "assetsInfo": {},
       "foreignAssetsInfo": {},
       "poolPairsInfo": {},
-      "specName": "bifrost"
+      "specName": "bifrost",
+      "xcAssetsData": [
+        {
+          "paraID": 0,
+          "symbol": "KSM",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
+          "asset": {
+            "Token": "KSM"
+          }
+        },
+        {
+          "paraID": 1000,
+          "symbol": "RMRK",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":8}]}}}",
+          "asset": {
+            "Token": "RMRK"
+          }
+        },
+        {
+          "paraID": 1000,
+          "symbol": "USDT",
+          "decimals": 6,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+          "asset": {
+            "Token2": "0"
+          }
+        },
+        {
+          "paraID": 2000,
+          "symbol": "KUSD",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0081\"}]}}}",
+          "asset": {
+            "Stable": "KUSD"
+          }
+        },
+        {
+          "paraID": 2000,
+          "symbol": "KAR",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0080\"}]}}}",
+          "asset": {
+            "Token": "KAR"
+          }
+        },
+        {
+          "paraID": 2001,
+          "symbol": "vBNC",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0101\"}]}}}",
+          "asset": {
+            "VToken": "BNC"
+          }
+        },
+        {
+          "paraID": 2001,
+          "symbol": "vMOVR",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x010a\"}]}}}",
+          "asset": {
+            "VToken": "MOVR"
+          }
+        },
+        {
+          "paraID": 2001,
+          "symbol": "vKSM",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0104\"}]}}}",
+          "asset": {
+            "VToken": "KSM"
+          }
+        },
+        {
+          "paraID": 2001,
+          "symbol": "ZLK",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0207\"}]}}}",
+          "asset": {
+            "Token": "ZLK"
+          }
+        },
+        {
+          "paraID": 2001,
+          "symbol": "VSvsKSM",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0404\"}]}}}",
+          "asset": {
+            "VSToken": "KSM"
+          }
+        },
+        {
+          "paraID": 2001,
+          "symbol": "BNC",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0001\"}]}}}",
+          "asset": {
+            "Native": "BNC"
+          }
+        },
+        {
+          "paraID": 2004,
+          "symbol": "PHA",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2004}}}}",
+          "asset": {
+            "Token": "PHA"
+          }
+        },
+        {
+          "paraID": 2007,
+          "symbol": "SDN",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2007}}}}",
+          "asset": {
+            "Token2": "3"
+          }
+        },
+        {
+          "paraID": 2023,
+          "symbol": "MOVR",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2023},{\"palletInstance\":10}]}}}",
+          "asset": {
+            "Token": "MOVR"
+          }
+        },
+        {
+          "paraID": 2092,
+          "symbol": "KBTC",
+          "decimals": 8,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2092},{\"generalKey\":\"0x000b\"}]}}}",
+          "asset": {
+            "Token2": "2"
+          }
+        },
+        {
+          "paraID": 2092,
+          "symbol": "KINT",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2092},{\"generalKey\":\"0x000c\"}]}}}",
+          "asset": {
+            "Token2": "1"
+          }
+        },
+        {
+          "paraID": 2110,
+          "symbol": "MGX",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2110},{\"generalKey\":\"0x00000000\"}]}}}",
+          "asset": {
+            "Token2": "4"
+          }
+        }
+      ]
     },
     "2004": {
       "tokens": [
@@ -624,7 +1897,121 @@
       "assetsInfo": {},
       "foreignAssetsInfo": {},
       "poolPairsInfo": {},
-      "specName": "khala"
+      "specName": "khala",
+      "xcAssetsData": [
+        {
+          "paraID": 0,
+          "symbol": "KSM",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
+          "asset": "0"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "KAR",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0080\"}]}}}",
+          "asset": "1"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "aUSD",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0081\"}]}}}",
+          "asset": "4"
+        },
+        {
+          "paraID": 2001,
+          "symbol": "BNC",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0001\"}]}}}",
+          "asset": "2"
+        },
+        {
+          "paraID": 2001,
+          "symbol": "ZLK",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0207\"}]}}}",
+          "asset": "3"
+        },
+        {
+          "paraID": 2007,
+          "symbol": "SDN",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2007}}}}",
+          "asset": "12"
+        },
+        {
+          "paraID": 2023,
+          "symbol": "MOVR",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2023},{\"palletInstance\":10}]}}}",
+          "asset": "6"
+        },
+        {
+          "paraID": 2084,
+          "symbol": "KMA",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2084}}}}",
+          "asset": "8"
+        },
+        {
+          "paraID": 2085,
+          "symbol": "HKO",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2085},{\"generalKey\":\"0x484b4f\"}]}}}",
+          "asset": "7"
+        },
+        {
+          "paraID": 2087,
+          "symbol": "PICA",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2087}}}}",
+          "asset": "15"
+        },
+        {
+          "paraID": 2090,
+          "symbol": "BSX",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2090},{\"generalKey\":\"0x00000000\"}]}}}",
+          "asset": "5"
+        },
+        {
+          "paraID": 2090,
+          "symbol": "BSX",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2090},{\"generalIndex\":0}]}}}",
+          "asset": "9"
+        },
+        {
+          "paraID": 2096,
+          "symbol": "NEER",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2096},{\"generalKey\":\"0x000000000000000000\"}]}}}",
+          "asset": "13"
+        },
+        {
+          "paraID": 2096,
+          "symbol": "BIT",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2096},{\"generalKey\":\"0x020000000000000000\"}]}}}",
+          "asset": "14"
+        },
+        {
+          "paraID": 2105,
+          "symbol": "CRAB",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2105},{\"palletInstance\":5}]}}}",
+          "asset": "11"
+        },
+        {
+          "paraID": 2114,
+          "symbol": "TUR",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2114}}}}",
+          "asset": "10"
+        }
+      ]
     },
     "2007": {
       "tokens": [
@@ -633,7 +2020,142 @@
       "assetsInfo": {},
       "foreignAssetsInfo": {},
       "poolPairsInfo": {},
-      "specName": "shiden"
+      "specName": "shiden",
+      "xcAssetsData": [
+        {
+          "paraID": 0,
+          "symbol": "KSM",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
+          "asset": "340282366920938463463374607431768211455"
+        },
+        {
+          "paraID": 1000,
+          "symbol": "USDT",
+          "decimals": 6,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+          "asset": "4294969280"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "KAR",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0080\"}]}}}",
+          "asset": "18446744073709551618"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "LKSM",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0083\"}]}}}",
+          "asset": "18446744073709551619"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "aSEED",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0081\"}]}}}",
+          "asset": "18446744073709551616"
+        },
+        {
+          "paraID": 2001,
+          "symbol": "BNC",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0001\"}]}}}",
+          "asset": "18446744073709551627"
+        },
+        {
+          "paraID": 2001,
+          "symbol": "vsKSM",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0404\"}]}}}",
+          "asset": "18446744073709551629"
+        },
+        {
+          "paraID": 2001,
+          "symbol": "vKSM",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0104\"}]}}}",
+          "asset": "18446744073709551628"
+        },
+        {
+          "paraID": 2004,
+          "symbol": "PHA",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2004}}}}",
+          "asset": "18446744073709551623"
+        },
+        {
+          "paraID": 2012,
+          "symbol": "CSM",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2012}}}}",
+          "asset": "18446744073709551624"
+        },
+        {
+          "paraID": 2016,
+          "symbol": "SKU",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2016}}}}",
+          "asset": "18446744073709551626"
+        },
+        {
+          "paraID": 2023,
+          "symbol": "MOVR",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2023},{\"palletInstance\":10}]}}}",
+          "asset": "18446744073709551620"
+        },
+        {
+          "paraID": 2024,
+          "symbol": "GENS",
+          "decimals": 9,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2024}}}}",
+          "asset": "18446744073709551630"
+        },
+        {
+          "paraID": 2024,
+          "symbol": "EQD",
+          "decimals": 9,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2024},{\"generalKey\":\"0x657164\"}]}}}",
+          "asset": "18446744073709551631"
+        },
+        {
+          "paraID": 2092,
+          "symbol": "KBTC",
+          "decimals": 8,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2092},{\"generalKey\":\"0x000b\"}]}}}",
+          "asset": "18446744073709551621"
+        },
+        {
+          "paraID": 2092,
+          "symbol": "KINT",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2092},{\"generalKey\":\"0x000c\"}]}}}",
+          "asset": "18446744073709551622"
+        },
+        {
+          "paraID": 2095,
+          "symbol": "QTZ",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2095}}}}",
+          "asset": "18446744073709551633"
+        },
+        {
+          "paraID": 2096,
+          "symbol": "NEER",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2096},{\"generalKey\":\"0x000000000000000000\"}]}}}",
+          "asset": "18446744073709551632"
+        },
+        {
+          "paraID": 2105,
+          "symbol": "CRAB",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2105},{\"palletInstance\":5}]}}}",
+          "asset": "18446744073709551625"
+        }
+      ]
     },
     "2011": {
       "tokens": [],
@@ -649,7 +2171,58 @@
       "assetsInfo": {},
       "foreignAssetsInfo": {},
       "poolPairsInfo": {},
-      "specName": "crust-collator"
+      "specName": "crust-collator",
+      "xcAssetsData": [
+        {
+          "paraID": 2000,
+          "symbol": "KAR",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0080\"}]}}}",
+          "asset": "10810581592933651521121702237638664357"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "AUSD",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0081\"}]}}}",
+          "asset": "214920334981412447805621250067209749032"
+        },
+        {
+          "paraID": 2001,
+          "symbol": "BNC",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0001\"}]}}}",
+          "asset": "319623561105283008236062145480775032445"
+        },
+        {
+          "paraID": 2007,
+          "symbol": "SDN",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2007}}}}",
+          "asset": "16797826370226091782818345603793389938"
+        },
+        {
+          "paraID": 2023,
+          "symbol": "MOVR",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2023},{\"palletInstance\":10}]}}}",
+          "asset": "232263652204149413431520870009560565298"
+        },
+        {
+          "paraID": 2048,
+          "symbol": "XRT",
+          "decimals": 9,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2048}}}}",
+          "asset": "108036400430056508975016746969135344601"
+        },
+        {
+          "paraID": 2105,
+          "symbol": "CRAB",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2105},{\"palletInstance\":5}]}}}",
+          "asset": "173481220575862801646329923366065693029"
+        }
+      ]
     },
     "2015": {
       "tokens": [
@@ -667,7 +2240,163 @@
       "assetsInfo": {},
       "foreignAssetsInfo": {},
       "poolPairsInfo": {},
-      "specName": "moonriver"
+      "specName": "moonriver",
+      "xcAssetsData": [
+        {
+          "paraID": 0,
+          "symbol": "KSM",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
+          "asset": "42259045809535163221576417993425387648"
+        },
+        {
+          "paraID": 1000,
+          "symbol": "USDT",
+          "decimals": 6,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+          "asset": "311091173110107856861649819128533077277"
+        },
+        {
+          "paraID": 1000,
+          "symbol": "RMRK",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":8}]}}}",
+          "asset": "182365888117048807484804376330534607370"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "aSeed",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0081\"}]}}}",
+          "asset": "214920334981412447805621250067209749032"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "KAR",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0080\"}]}}}",
+          "asset": "10810581592933651521121702237638664357"
+        },
+        {
+          "paraID": 2001,
+          "symbol": "vKSM",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0104\"}]}}}",
+          "asset": "264344629840762281112027368930249420542"
+        },
+        {
+          "paraID": 2001,
+          "symbol": "vBNC",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0101\"}]}}}",
+          "asset": "72145018963825376852137222787619937732"
+        },
+        {
+          "paraID": 2001,
+          "symbol": "vMOVR",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x010a\"}]}}}",
+          "asset": "203223821023327994093278529517083736593"
+        },
+        {
+          "paraID": 2001,
+          "symbol": "BNC",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0001\"}]}}}",
+          "asset": "319623561105283008236062145480775032445"
+        },
+        {
+          "paraID": 2004,
+          "symbol": "PHA",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2004}}}}",
+          "asset": "189307976387032586987344677431204943363"
+        },
+        {
+          "paraID": 2007,
+          "symbol": "SDN",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2007}}}}",
+          "asset": "16797826370226091782818345603793389938"
+        },
+        {
+          "paraID": 2012,
+          "symbol": "CSM",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2012}}}}",
+          "asset": "108457044225666871745333730479173774551"
+        },
+        {
+          "paraID": 2015,
+          "symbol": "TEER",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2015},{\"generalKey\":\"0x54454552\"}]}}}",
+          "asset": "105075627293246237499203909093923548958"
+        },
+        {
+          "paraID": 2048,
+          "symbol": "XRT",
+          "decimals": 9,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2048}}}}",
+          "asset": "108036400430056508975016746969135344601"
+        },
+        {
+          "paraID": 2084,
+          "symbol": "KMA",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2084}}}}",
+          "asset": "213357169630950964874127107356898319277"
+        },
+        {
+          "paraID": 2085,
+          "symbol": "HKO",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2085},{\"generalKey\":\"0x484b4f\"}]}}}",
+          "asset": "76100021443485661246318545281171740067"
+        },
+        {
+          "paraID": 2092,
+          "symbol": "KBTC",
+          "decimals": 8,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2092},{\"generalKey\":\"0x000b\"}]}}}",
+          "asset": "328179947973504579459046439826496046832"
+        },
+        {
+          "paraID": 2092,
+          "symbol": "KINT",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2092},{\"generalKey\":\"0x000c\"}]}}}",
+          "asset": "175400718394635817552109270754364440562"
+        },
+        {
+          "paraID": 2105,
+          "symbol": "CRAB",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2105},{\"palletInstance\":5}]}}}",
+          "asset": "173481220575862801646329923366065693029"
+        },
+        {
+          "paraID": 2106,
+          "symbol": "LIT",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2106},{\"palletInstance\":10}]}}}",
+          "asset": "65216491554813189869575508812319036608"
+        },
+        {
+          "paraID": 2110,
+          "symbol": "MGX",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2110},{\"generalKey\":\"0x00000000\"}]}}}",
+          "asset": "118095707745084482624853002839493125353"
+        },
+        {
+          "paraID": 2114,
+          "symbol": "TUR",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2114}}}}",
+          "asset": "133300872918374599700079037156071917454"
+        }
+      ]
     },
     "2024": {
       "tokens": [
@@ -700,7 +2429,149 @@
       "assetsInfo": {},
       "foreignAssetsInfo": {},
       "poolPairsInfo": {},
-      "specName": "calamari"
+      "specName": "calamari",
+      "xcAssetsData": [
+        {
+          "paraID": 0,
+          "symbol": "KSM",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
+          "asset": "12"
+        },
+        {
+          "paraID": 1000,
+          "symbol": "USDT",
+          "decimals": 6,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+          "asset": "14"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "KAR",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0080\"}]}}}",
+          "asset": "8"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "AUSD",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0081\"}]}}}",
+          "asset": "9"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "LKSM",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0083\"}]}}}",
+          "asset": "10"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "USDC",
+          "decimals": 6,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x021f3a10587a20114ea25ba1b388ee2dd4a337ce27\"}]}}}",
+          "asset": "16"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "LINK",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x022c7de70b32cf5f20e02329a88d2e3b00ef85eb90\"}]}}}",
+          "asset": "24"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "APE",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0230b1f4ba0b07789be9986fa090a57e0fe5631ebb\"}]}}}",
+          "asset": "25"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "DAI",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x024bb6afb5fa2b07a5d1c499e1c3ddb5a15e709a71\"}]}}}",
+          "asset": "15"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "BUSD",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x02577f6a0718a468e8a995f6075f2325f86a07c83b\"}]}}}",
+          "asset": "23"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "WBTC",
+          "decimals": 8,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0266291c7d88d2ed9a708147bae4e0814a76705e2f\"}]}}}",
+          "asset": "26"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "UNI",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0277cf14f938cb97308d752647d554439d99b39a3f\"}]}}}",
+          "asset": "22"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "SHIB",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x029759ca009cbcd75a84786ac19bb5d02f8e68bcd9\"}]}}}",
+          "asset": "19"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "MATIC",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x02a2a37aaf4730aeedada5aa8ee20a4451cb8b1c4e\"}]}}}",
+          "asset": "20"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "LDO",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x02b4ce1f6109854243d1af13b8ea34ed28542f31e0\"}]}}}",
+          "asset": "18"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "ARB",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x02c621abc3afa3f24886ea278fffa7e10e8969d755\"}]}}}",
+          "asset": "17"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "BNB",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x02e278651e8ff8e2efa83d7f84205084ebc90688be\"}]}}}",
+          "asset": "21"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "WETH",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x02ece0cc38021e734bef1d5da071b027ac2f71181f\"}]}}}",
+          "asset": "27"
+        },
+        {
+          "paraID": 2004,
+          "symbol": "PHA",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2004}}}}",
+          "asset": "13"
+        },
+        {
+          "paraID": 2023,
+          "symbol": "MOVR",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2023},{\"palletInstance\":10}]}}}",
+          "asset": "11"
+        }
+      ]
     },
     "2085": {
       "tokens": [
@@ -709,7 +2580,72 @@
       "assetsInfo": {},
       "foreignAssetsInfo": {},
       "poolPairsInfo": {},
-      "specName": "heiko"
+      "specName": "heiko",
+      "xcAssetsData": [
+        {
+          "paraID": 0,
+          "symbol": "KSM",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
+          "asset": "100"
+        },
+        {
+          "paraID": 1000,
+          "symbol": "USDT",
+          "decimals": 6,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+          "asset": "102"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "LKSM",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0083\"}]}}}",
+          "asset": "109"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "KAR",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0080\"}]}}}",
+          "asset": "107"
+        },
+        {
+          "paraID": 2004,
+          "symbol": "PHA",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2004}}}}",
+          "asset": "115"
+        },
+        {
+          "paraID": 2023,
+          "symbol": "MOVR",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2023},{\"palletInstance\":10}]}}}",
+          "asset": "113"
+        },
+        {
+          "paraID": 2085,
+          "symbol": "sKSM",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2085},{\"palletInstance\":6},{\"generalIndex\":1000}]}}}",
+          "asset": "1000"
+        },
+        {
+          "paraID": 2092,
+          "symbol": "KBTC",
+          "decimals": 8,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2092},{\"generalKey\":\"0x000b\"}]}}}",
+          "asset": "121"
+        },
+        {
+          "paraID": 2092,
+          "symbol": "KINT",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2092},{\"generalKey\":\"0x000c\"}]}}}",
+          "asset": "119"
+        }
+      ]
     },
     "2087": {
       "tokens": [
@@ -727,7 +2663,43 @@
       "assetsInfo": {},
       "foreignAssetsInfo": {},
       "poolPairsInfo": {},
-      "specName": "altair"
+      "specName": "altair",
+      "xcAssetsData": [
+        {
+          "paraID": 0,
+          "symbol": "KSM",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
+          "asset": {
+            "ForeignAsset": "3"
+          }
+        },
+        {
+          "paraID": 1000,
+          "symbol": "USDT",
+          "decimals": 6,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+          "asset": {
+            "ForeignAsset": "1"
+          }
+        },
+        {
+          "paraID": 2000,
+          "symbol": "aUSD",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0081\"}]}}}",
+          "asset": {
+            "ForeignAsset": "2"
+          }
+        },
+        {
+          "paraID": 2088,
+          "symbol": "AIR",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2088},{\"generalKey\":\"0x0001\"}]}}}",
+          "asset": "Native"
+        }
+      ]
     },
     "2090": {
       "tokens": [
@@ -736,7 +2708,79 @@
       "assetsInfo": {},
       "foreignAssetsInfo": {},
       "poolPairsInfo": {},
-      "specName": "basilisk"
+      "specName": "basilisk",
+      "xcAssetsData": [
+        {
+          "paraID": 0,
+          "symbol": "KSM",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
+          "asset": "1"
+        },
+        {
+          "paraID": 1000,
+          "symbol": "USDT",
+          "decimals": 6,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+          "asset": "14"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "DAI",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x024bb6afb5fa2b07a5d1c499e1c3ddb5a15e709a71\"}]}}}",
+          "asset": "13"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "USDCet",
+          "decimals": 6,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x021f3a10587a20114ea25ba1b388ee2dd4a337ce27\"}]}}}",
+          "asset": "9"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "aUSD",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0081\"}]}}}",
+          "asset": "2"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "wETH",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x02ece0cc38021e734bef1d5da071b027ac2f71181f\"}]}}}",
+          "asset": "10"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "wBTC",
+          "decimals": 8,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0266291c7d88d2ed9a708147bae4e0814a76705e2f\"}]}}}",
+          "asset": "11"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "wUSDT",
+          "decimals": 6,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0254e183e533fd3c6e72debb2d1cab451d017faf72\"}]}}}",
+          "asset": "12"
+        },
+        {
+          "paraID": 2048,
+          "symbol": "XRT",
+          "decimals": 9,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2048}}}}",
+          "asset": "16"
+        },
+        {
+          "paraID": 2125,
+          "symbol": "TNKR",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2125},{\"generalIndex\":0}]}}}",
+          "asset": "6"
+        }
+      ]
     },
     "2092": {
       "tokens": [
@@ -750,7 +2794,63 @@
       "assetsInfo": {},
       "foreignAssetsInfo": {},
       "poolPairsInfo": {},
-      "specName": "kintsugi-parachain"
+      "specName": "kintsugi-parachain",
+      "xcAssetsData": [
+        {
+          "paraID": 1000,
+          "symbol": "USDT",
+          "decimals": 6,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+          "asset": {
+            "ForeignAsset": "3"
+          }
+        },
+        {
+          "paraID": 2000,
+          "symbol": "AUSD",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0081\"}]}}}",
+          "asset": {
+            "ForeignAsset": "1"
+          }
+        },
+        {
+          "paraID": 2000,
+          "symbol": "LKSM",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0083\"}]}}}",
+          "asset": {
+            "ForeignAsset": "2"
+          }
+        },
+        {
+          "paraID": 2001,
+          "symbol": "VKSM",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0104\"}]}}}",
+          "asset": {
+            "ForeignAsset": "5"
+          }
+        },
+        {
+          "paraID": 2023,
+          "symbol": "MOVR",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2023},{\"palletInstance\":10}]}}}",
+          "asset": {
+            "ForeignAsset": "4"
+          }
+        },
+        {
+          "paraID": 2085,
+          "symbol": "SKSM",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2085},{\"palletInstance\":6},{\"generalIndex\":1000}]}}}",
+          "asset": {
+            "ForeignAsset": "6"
+          }
+        }
+      ]
     },
     "2095": {
       "tokens": [
@@ -795,7 +2895,72 @@
       "assetsInfo": {},
       "foreignAssetsInfo": {},
       "poolPairsInfo": {},
-      "specName": "mangata-parachain"
+      "specName": "mangata-parachain",
+      "xcAssetsData": [
+        {
+          "paraID": 1000,
+          "symbol": "USDT",
+          "decimals": 6,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+          "asset": "30"
+        },
+        {
+          "paraID": 1000,
+          "symbol": "RMRK",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":8}]}}}",
+          "asset": "31"
+        },
+        {
+          "paraID": 2001,
+          "symbol": "BNC",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0001\"}]}}}",
+          "asset": "14"
+        },
+        {
+          "paraID": 2001,
+          "symbol": "vBNC",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0101\"}]}}}",
+          "asset": "23"
+        },
+        {
+          "paraID": 2001,
+          "symbol": "vKSM",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0104\"}]}}}",
+          "asset": "15"
+        },
+        {
+          "paraID": 2001,
+          "symbol": "ZLK",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0207\"}]}}}",
+          "asset": "26"
+        },
+        {
+          "paraID": 2001,
+          "symbol": "vsKSM",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0404\"}]}}}",
+          "asset": "16"
+        },
+        {
+          "paraID": 2114,
+          "symbol": "TUR",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2114}}}}",
+          "asset": "7"
+        },
+        {
+          "paraID": 2121,
+          "symbol": "IMBU",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2121},{\"generalKey\":\"0x0096\"}]}}}",
+          "asset": "11"
+        }
+      ]
     },
     "2113": {
       "tokens": [
@@ -813,7 +2978,78 @@
       "assetsInfo": {},
       "foreignAssetsInfo": {},
       "poolPairsInfo": {},
-      "specName": "turing"
+      "specName": "turing",
+      "xcAssetsData": [
+        {
+          "paraID": 0,
+          "symbol": "KSM",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
+          "asset": "1"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "AUSD",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0081\"}]}}}",
+          "asset": "2"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "KAR",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0080\"}]}}}",
+          "asset": "3"
+        },
+        {
+          "paraID": 2000,
+          "symbol": "LKSM",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0083\"}]}}}",
+          "asset": "4"
+        },
+        {
+          "paraID": 2004,
+          "symbol": "PHA",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2004}}}}",
+          "asset": "7"
+        },
+        {
+          "paraID": 2007,
+          "symbol": "SDN",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2007}}}}",
+          "asset": "8"
+        },
+        {
+          "paraID": 2023,
+          "symbol": "MOVR",
+          "decimals": 18,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2023},{\"palletInstance\":10}]}}}",
+          "asset": "9"
+        },
+        {
+          "paraID": 2085,
+          "symbol": "HKO",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2085},{\"generalKey\":\"0x484b4f\"}]}}}",
+          "asset": "5"
+        },
+        {
+          "symbol": "TUR",
+          "decimals": 10,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2114}}}}",
+          "asset": "0"
+        },
+        {
+          "paraID": 2085,
+          "symbol": "SKSM",
+          "decimals": 12,
+          "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2085},{\"generalKey\":\"0x734b534d\"}]}}}",
+          "asset": "6"
+        }
+      ]
     },
     "2119": {
       "tokens": [
@@ -1164,11406 +3400,5 @@
       "poolPairsInfo": {},
       "specName": "collectives"
     }
-  },
-  "xcAssets": {
-    "polkadot": [
-      {
-        "relayChain": "polkadot",
-        "paraID": 2000,
-        "id": "acala",
-        "xcAssetCnt": "13",
-        "data": [
-          {
-            "paraID": 1000,
-            "relayChain": "polkadot",
-            "nativeChainID": "statemint",
-            "symbol": "USDT",
-            "decimals": 6,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 1000
-              },
-              {
-                "palletInstance": 50
-              },
-              {
-                "generalIndex": 1984
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 1000
-                    },
-                    {
-                      "palletInstance": 50
-                    },
-                    {
-                      "generalIndex": 1984
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "12"
-            },
-            "source": [
-              "2000"
-            ]
-          },
-          {
-            "paraID": 1000,
-            "relayChain": "polkadot",
-            "nativeChainID": "statemint",
-            "symbol": "WETH",
-            "decimals": 18,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 1000
-              },
-              {
-                "palletInstance": 50
-              },
-              {
-                "generalIndex": 100
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 1000
-                    },
-                    {
-                      "palletInstance": 50
-                    },
-                    {
-                      "generalIndex": 100
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "6"
-            },
-            "source": [
-              "2000"
-            ]
-          },
-          {
-            "paraID": 1000,
-            "relayChain": "polkadot",
-            "nativeChainID": "statemint",
-            "symbol": "WBTC",
-            "decimals": 8,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 1000
-              },
-              {
-                "palletInstance": 50
-              },
-              {
-                "generalIndex": 21
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 1000
-                    },
-                    {
-                      "palletInstance": 50
-                    },
-                    {
-                      "generalIndex": 21
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "5"
-            },
-            "source": [
-              "2000"
-            ]
-          },
-          {
-            "paraID": 2004,
-            "relayChain": "polkadot",
-            "nativeChainID": "moonbeam",
-            "symbol": "GLMR",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2004
-              },
-              {
-                "palletInstance": 10
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2004
-                    },
-                    {
-                      "palletInstance": 10
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "0"
-            },
-            "source": [
-              "2000"
-            ]
-          },
-          {
-            "paraID": 2006,
-            "relayChain": "polkadot",
-            "nativeChainID": "astar",
-            "symbol": "ASTR",
-            "decimals": 18,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2006
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2006
-                  }
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "2"
-            },
-            "source": [
-              "2000"
-            ]
-          },
-          {
-            "paraID": 2008,
-            "relayChain": "polkadot",
-            "nativeChainID": null,
-            "symbol": "CRU",
-            "decimals": 12,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2008
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2008
-                  }
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "11"
-            },
-            "source": [
-              "2000"
-            ]
-          },
-          {
-            "paraID": 2011,
-            "relayChain": "polkadot",
-            "nativeChainID": "equilibrium",
-            "symbol": "EQD",
-            "decimals": 9,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2011
-              },
-              {
-                "generalKey": "0x657164"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2011
-                    },
-                    {
-                      "generalKey": "0x657164"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "8"
-            },
-            "source": [
-              "2000"
-            ]
-          },
-          {
-            "paraID": 2011,
-            "relayChain": "polkadot",
-            "nativeChainID": "equilibrium",
-            "symbol": "EQ",
-            "decimals": 9,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2011
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2011
-                  }
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "7"
-            },
-            "source": [
-              "2000"
-            ]
-          },
-          {
-            "paraID": 2012,
-            "relayChain": "polkadot",
-            "nativeChainID": "parallel",
-            "symbol": "PARA",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2012
-              },
-              {
-                "generalKey": "0x50415241"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2012
-                    },
-                    {
-                      "generalKey": "0x50415241"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "1"
-            },
-            "source": [
-              "2000"
-            ]
-          },
-          {
-            "paraID": 2032,
-            "relayChain": "polkadot",
-            "nativeChainID": "interlay",
-            "symbol": "IBTC",
-            "decimals": 8,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2032
-              },
-              {
-                "generalKey": "0x0001"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2032
-                    },
-                    {
-                      "generalKey": "0x0001"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "3"
-            },
-            "source": [
-              "2000"
-            ]
-          },
-          {
-            "paraID": 2032,
-            "relayChain": "polkadot",
-            "nativeChainID": "interlay",
-            "symbol": "INTR",
-            "decimals": 10,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2032
-              },
-              {
-                "generalKey": "0x0002"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2032
-                    },
-                    {
-                      "generalKey": "0x0002"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "4"
-            },
-            "source": [
-              "2000"
-            ]
-          },
-          {
-            "paraID": 2035,
-            "relayChain": "polkadot",
-            "nativeChainID": "phala",
-            "symbol": "PHA",
-            "decimals": 12,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2035
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2035
-                  }
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "9"
-            },
-            "source": [
-              "2000"
-            ]
-          },
-          {
-            "paraID": 2037,
-            "relayChain": "polkadot",
-            "nativeChainID": "unique",
-            "symbol": "UNQ",
-            "decimals": 18,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2037
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2037
-                  }
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "10"
-            },
-            "source": [
-              "2000"
-            ]
-          }
-        ]
-      },
-      {
-        "relayChain": "polkadot",
-        "paraID": 2002,
-        "id": "clover",
-        "xcAssetCnt": "2",
-        "data": [
-          {
-            "paraID": 2006,
-            "relayChain": "polkadot",
-            "nativeChainID": "astar",
-            "symbol": "ASTR",
-            "decimals": 18,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2006
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010100591f",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2006
-                  }
-                }
-              }
-            },
-            "asset": "12",
-            "source": [
-              "2002"
-            ]
-          },
-          {
-            "paraID": 2012,
-            "relayChain": "polkadot",
-            "nativeChainID": "parallel",
-            "symbol": "PARA",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2012
-              },
-              {
-                "generalKey": "0x50415241"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200711f061050415241",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2012
-                    },
-                    {
-                      "generalKey": "0x50415241"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "11",
-            "source": [
-              "2002"
-            ]
-          }
-        ]
-      },
-      {
-        "relayChain": "polkadot",
-        "paraID": 2004,
-        "id": "moonbeam",
-        "xcAssetCnt": "22",
-        "data": [
-          {
-            "paraID": 0,
-            "relayChain": "polkadot",
-            "nativeChainID": "polkadot",
-            "symbol": "DOT",
-            "decimals": 10,
-            "interiorType": "here",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              "here"
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "here": null
-                }
-              }
-            },
-            "asset": "42259045809535163221576417993425387648",
-            "contractAddress": "0xffffffff1fcacbd218edc0eba20fc2308c778080",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 1000,
-            "relayChain": "polkadot",
-            "nativeChainID": "statemint",
-            "symbol": "USDT",
-            "decimals": 6,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 1000
-              },
-              {
-                "palletInstance": 50
-              },
-              {
-                "generalIndex": 1984
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 1000
-                    },
-                    {
-                      "palletInstance": 50
-                    },
-                    {
-                      "generalIndex": 1984
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "311091173110107856861649819128533077277",
-            "contractAddress": "0xffffffffea09fb06d082fd1275cd48b191cbcd1d",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "polkadot",
-            "nativeChainID": "acala",
-            "symbol": "aUSD",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0001"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0001"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "110021739665376159354538090254163045594",
-            "contractAddress": "0xffffffff52c56a9257bb97f4b2b6f7b2d624ecda",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "polkadot",
-            "nativeChainID": "acala",
-            "symbol": "ACA",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0000"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0000"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "224821240862170613278369189818311486111",
-            "contractAddress": "0xffffffffa922fef94566104a6e5a35a4fcddaa9f",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2006,
-            "relayChain": "polkadot",
-            "nativeChainID": "astar",
-            "symbol": "ASTR",
-            "decimals": 18,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2006
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2006
-                  }
-                }
-              }
-            },
-            "asset": "224077081838586484055667086558292981199",
-            "contractAddress": "0xffffffffa893ad19e540e172c10d78d4d479b5cf",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2011,
-            "relayChain": "polkadot",
-            "nativeChainID": "equilibrium",
-            "symbol": "EQD",
-            "decimals": 9,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2011
-              },
-              {
-                "generalKey": "0x657164"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2011
-                    },
-                    {
-                      "generalKey": "0x657164"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "187224307232923873519830480073807488153",
-            "contractAddress": "0xffffffff8cda1707baf23834d211b08726b1e499",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2011,
-            "relayChain": "polkadot",
-            "nativeChainID": "equilibrium",
-            "symbol": "EQ",
-            "decimals": 9,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2011
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2011
-                  }
-                }
-              }
-            },
-            "asset": "190590555344745888270686124937537713878",
-            "contractAddress": "0xffffffff8f6267e040d8a0638c576dfba4f0f6d6",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2012,
-            "relayChain": "polkadot",
-            "nativeChainID": "parallel",
-            "symbol": "PARA",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2012
-              },
-              {
-                "generalKey": "0x50415241"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2012
-                    },
-                    {
-                      "generalKey": "0x50415241"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "32615670524745285411807346420584982855",
-            "contractAddress": "0xffffffff18898cb5fe1e88e668152b4f4052a947",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2026,
-            "relayChain": "polkadot",
-            "nativeChainID": "nodle",
-            "symbol": "NODL",
-            "decimals": 11,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2026
-              },
-              {
-                "palletInstance": 2
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2026
-                    },
-                    {
-                      "palletInstance": 2
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "309163521958167876851250718453738106865",
-            "contractAddress": "0xffffffffe896ba7cb118b9fa571c6dc0a99deff1",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2030,
-            "relayChain": "polkadot",
-            "nativeChainID": "bifrost",
-            "symbol": "FIL",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2030
-              },
-              {
-                "generalKey": "0x0804"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2030
-                    },
-                    {
-                      "generalKey": "0x0804"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "144012926827374458669278577633504620722",
-            "contractAddress": "0xffffffff6c57e17d210df507c82807149ffd70b2",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2030,
-            "relayChain": "polkadot",
-            "nativeChainID": "bifrost",
-            "symbol": "vDOT",
-            "decimals": 10,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2030
-              },
-              {
-                "generalKey": "0x0900"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2030
-                    },
-                    {
-                      "generalKey": "0x0900"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "29085784439601774464560083082574142143",
-            "contractAddress": "0xffffffff15e1b7e3df971dd813bc394deb899abf",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2030,
-            "relayChain": "polkadot",
-            "nativeChainID": "bifrost",
-            "symbol": "vGLMR",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2030
-              },
-              {
-                "generalKey": "0x0901"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2030
-                    },
-                    {
-                      "generalKey": "0x0901"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "204507659831918931608354793288110796652",
-            "contractAddress": "0xffffffff99dabe1a8de0ea22baa6fd48fde96f6c",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2030,
-            "relayChain": "polkadot",
-            "nativeChainID": "bifrost",
-            "symbol": "BNC",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2030
-              },
-              {
-                "generalKey": "0x0001"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2030
-                    },
-                    {
-                      "generalKey": "0x0001"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "165823357460190568952172802245839421906",
-            "contractAddress": "0xffffffff7cc06abdf7201b350a1265c62c8601d2",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2030,
-            "relayChain": "polkadot",
-            "nativeChainID": "bifrost",
-            "symbol": "vFIL",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2030
-              },
-              {
-                "generalKey": "0x0904"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2030
-                    },
-                    {
-                      "generalKey": "0x0904"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "272547899416482196831721420898811311297",
-            "contractAddress": "0xffffffffcd0ad0ea6576b7b285295c85e94cf4c1",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2031,
-            "relayChain": "polkadot",
-            "nativeChainID": "centrifuge",
-            "symbol": "CFG",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2031
-              },
-              {
-                "generalKey": "0x0001"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2031
-                    },
-                    {
-                      "generalKey": "0x0001"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "91372035960551235635465443179559840483",
-            "contractAddress": "0xffffffff44bd9d2ffee20b25d1cf9e78edb6eae3",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2032,
-            "relayChain": "polkadot",
-            "nativeChainID": "interlay",
-            "symbol": "IBTC",
-            "decimals": 8,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2032
-              },
-              {
-                "generalKey": "0x0001"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2032
-                    },
-                    {
-                      "generalKey": "0x0001"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "120637696315203257380661607956669368914",
-            "contractAddress": "0xffffffff5ac1f9a51a93f5c527385edf7fe98a52",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2032,
-            "relayChain": "polkadot",
-            "nativeChainID": "interlay",
-            "symbol": "INTR",
-            "decimals": 10,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2032
-              },
-              {
-                "generalKey": "0x0002"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2032
-                    },
-                    {
-                      "generalKey": "0x0002"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "101170542313601871197860408087030232491",
-            "contractAddress": "0xffffffff4c1cbcd97597339702436d4f18a375ab",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2034,
-            "relayChain": "polkadot",
-            "nativeChainID": "hydra",
-            "symbol": "HDX",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2034
-              },
-              {
-                "generalIndex": 0
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2034
-                    },
-                    {
-                      "generalIndex": 0
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "69606720909260275826784788104880799692",
-            "contractAddress": "0xffffffff345dc44ddae98df024eb494321e73fcc",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2035,
-            "relayChain": "polkadot",
-            "nativeChainID": "phala",
-            "symbol": "PHA",
-            "decimals": 12,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2035
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2035
-                  }
-                }
-              }
-            },
-            "asset": "132685552157663328694213725410064821485",
-            "contractAddress": "0xffffffff63d24ecc8eb8a7b5d0803e900f7b6ced",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2046,
-            "relayChain": "polkadot",
-            "nativeChainID": "darwinia",
-            "symbol": "RING",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2046
-              },
-              {
-                "palletInstance": 5
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2046
-                    },
-                    {
-                      "palletInstance": 5
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "125699734534028342599692732320197985871",
-            "contractAddress": "0xffffffff5e90e365edca87fb4c8306df1e91464f",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2101,
-            "relayChain": "polkadot",
-            "nativeChainID": null,
-            "symbol": "SUB",
-            "decimals": 10,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2101
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2101
-                  }
-                }
-              }
-            },
-            "asset": "89994634370519791027168048838578580624",
-            "contractAddress": "0xffffffff43b4560bc0c451a3386e082bff50ac90",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2104,
-            "relayChain": "polkadot",
-            "nativeChainID": null,
-            "symbol": "MANTA",
-            "decimals": 18,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2104
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2104
-                  }
-                }
-              }
-            },
-            "asset": "166446646689194205559791995948102903873",
-            "contractAddress": "0xffffffff7d3875460d4509eb8d0362c611b4e841",
-            "source": [
-              "2004"
-            ]
-          }
-        ]
-      },
-      {
-        "relayChain": "polkadot",
-        "paraID": 2006,
-        "id": "astar",
-        "xcAssetCnt": "18",
-        "data": [
-          {
-            "paraID": 0,
-            "relayChain": "polkadot",
-            "nativeChainID": "polkadot",
-            "symbol": "DOT",
-            "decimals": 10,
-            "interiorType": "here",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              "here"
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "here": null
-                }
-              }
-            },
-            "asset": "340282366920938463463374607431768211455",
-            "contractAddress": "0xffffffffffffffffffffffffffffffffffffffff",
-            "source": [
-              "2006"
-            ]
-          },
-          {
-            "paraID": 1000,
-            "relayChain": "polkadot",
-            "nativeChainID": "statemint",
-            "symbol": "USDT",
-            "decimals": 6,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 1000
-              },
-              {
-                "palletInstance": 50
-              },
-              {
-                "generalIndex": 1984
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 1000
-                    },
-                    {
-                      "palletInstance": 50
-                    },
-                    {
-                      "generalIndex": 1984
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "4294969280",
-            "contractAddress": "0xffffffff000000000000000000000001000007c0",
-            "source": [
-              "2006"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "polkadot",
-            "nativeChainID": "acala",
-            "symbol": "LDOT",
-            "decimals": 10,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0003"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0003"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "18446744073709551618",
-            "contractAddress": "0xffffffff00000000000000010000000000000002",
-            "source": [
-              "2006"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "polkadot",
-            "nativeChainID": "acala",
-            "symbol": "ACA",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0000"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0000"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "18446744073709551616",
-            "contractAddress": "0xffffffff00000000000000010000000000000000",
-            "source": [
-              "2006"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "polkadot",
-            "nativeChainID": "acala",
-            "symbol": "aSEED",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0001"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0001"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "18446744073709551617",
-            "contractAddress": "0xffffffff00000000000000010000000000000001",
-            "source": [
-              "2006"
-            ]
-          },
-          {
-            "paraID": 2002,
-            "relayChain": "polkadot",
-            "nativeChainID": "clover",
-            "symbol": "CLV",
-            "decimals": 18,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2002
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2002
-                  }
-                }
-              }
-            },
-            "asset": "18446744073709551625",
-            "contractAddress": "0xffffffff00000000000000010000000000000009",
-            "source": [
-              "2006"
-            ]
-          },
-          {
-            "paraID": 2004,
-            "relayChain": "polkadot",
-            "nativeChainID": "moonbeam",
-            "symbol": "GLMR",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2004
-              },
-              {
-                "palletInstance": 10
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2004
-                    },
-                    {
-                      "palletInstance": 10
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "18446744073709551619",
-            "contractAddress": "0xffffffff00000000000000010000000000000003",
-            "source": [
-              "2006"
-            ]
-          },
-          {
-            "paraID": 2011,
-            "relayChain": "polkadot",
-            "nativeChainID": "equilibrium",
-            "symbol": "EQD",
-            "decimals": 9,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2011
-              },
-              {
-                "generalKey": "0x657164"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2011
-                    },
-                    {
-                      "generalKey": "0x657164"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "18446744073709551629",
-            "contractAddress": "0xffffffff0000000000000001000000000000000d",
-            "source": [
-              "2006"
-            ]
-          },
-          {
-            "paraID": 2011,
-            "relayChain": "polkadot",
-            "nativeChainID": "equilibrium",
-            "symbol": "EQ",
-            "decimals": 9,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2011
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2011
-                  }
-                }
-              }
-            },
-            "asset": "18446744073709551628",
-            "contractAddress": "0xffffffff0000000000000001000000000000000c",
-            "source": [
-              "2006"
-            ]
-          },
-          {
-            "paraID": 2030,
-            "relayChain": "polkadot",
-            "nativeChainID": "bifrost",
-            "symbol": "vsDOT",
-            "decimals": 10,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2030
-              },
-              {
-                "generalKey": "0x0403"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2030
-                    },
-                    {
-                      "generalKey": "0x0403"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "18446744073709551626",
-            "contractAddress": "0xffffffff0000000000000001000000000000000a",
-            "source": [
-              "2006"
-            ]
-          },
-          {
-            "paraID": 2030,
-            "relayChain": "polkadot",
-            "nativeChainID": "bifrost",
-            "symbol": "vDOT",
-            "decimals": 10,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2030
-              },
-              {
-                "generalKey": "0x0900"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2030
-                    },
-                    {
-                      "generalKey": "0x0900"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "18446744073709551624",
-            "contractAddress": "0xffffffff00000000000000010000000000000008",
-            "source": [
-              "2006"
-            ]
-          },
-          {
-            "paraID": 2030,
-            "relayChain": "polkadot",
-            "nativeChainID": "bifrost",
-            "symbol": "BNC",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2030
-              },
-              {
-                "generalKey": "0x0001"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2030
-                    },
-                    {
-                      "generalKey": "0x0001"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "18446744073709551623",
-            "contractAddress": "0xffffffff00000000000000010000000000000007",
-            "source": [
-              "2006"
-            ]
-          },
-          {
-            "paraID": 2032,
-            "relayChain": "polkadot",
-            "nativeChainID": "interlay",
-            "symbol": "IBTC",
-            "decimals": 8,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2032
-              },
-              {
-                "generalKey": "0x0001"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2032
-                    },
-                    {
-                      "generalKey": "0x0001"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "18446744073709551620",
-            "contractAddress": "0xffffffff00000000000000010000000000000004",
-            "source": [
-              "2006"
-            ]
-          },
-          {
-            "paraID": 2032,
-            "relayChain": "polkadot",
-            "nativeChainID": "interlay",
-            "symbol": "INTR",
-            "decimals": 10,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2032
-              },
-              {
-                "generalKey": "0x0002"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2032
-                    },
-                    {
-                      "generalKey": "0x0002"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "18446744073709551621",
-            "contractAddress": "0xffffffff00000000000000010000000000000005",
-            "source": [
-              "2006"
-            ]
-          },
-          {
-            "paraID": 2034,
-            "relayChain": "polkadot",
-            "nativeChainID": "hydra",
-            "symbol": "HDX",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2034
-              },
-              {
-                "generalIndex": 0
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2034
-                    },
-                    {
-                      "generalIndex": 0
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "18446744073709551630",
-            "contractAddress": "0xffffffff0000000000000001000000000000000e",
-            "source": [
-              "2006"
-            ]
-          },
-          {
-            "paraID": 2035,
-            "relayChain": "polkadot",
-            "nativeChainID": "phala",
-            "symbol": "PHA",
-            "decimals": 12,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2035
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2035
-                  }
-                }
-              }
-            },
-            "asset": "18446744073709551622",
-            "contractAddress": "0xffffffff00000000000000010000000000000006",
-            "source": [
-              "2006"
-            ]
-          },
-          {
-            "paraID": 2037,
-            "relayChain": "polkadot",
-            "nativeChainID": "unique",
-            "symbol": "UNQ",
-            "decimals": 18,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2037
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2037
-                  }
-                }
-              }
-            },
-            "asset": "18446744073709551631",
-            "contractAddress": "0xffffffff0000000000000001000000000000000f",
-            "source": [
-              "2006"
-            ]
-          },
-          {
-            "paraID": 2046,
-            "relayChain": "polkadot",
-            "nativeChainID": "darwinia",
-            "symbol": "RING",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2046
-              },
-              {
-                "palletInstance": 5
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2046
-                    },
-                    {
-                      "palletInstance": 5
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "18446744073709551627",
-            "contractAddress": "0xffffffff0000000000000001000000000000000b",
-            "source": [
-              "2006"
-            ]
-          }
-        ]
-      },
-      {
-        "relayChain": "polkadot",
-        "paraID": 2012,
-        "id": "parallel",
-        "xcAssetCnt": "16",
-        "data": [
-          {
-            "paraID": 0,
-            "relayChain": "polkadot",
-            "nativeChainID": "polkadot",
-            "symbol": "DOT",
-            "decimals": 10,
-            "interiorType": "here",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              "here"
-            ],
-            "xcmV1MultiLocationByte": "0x0100",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "here": null
-                }
-              }
-            },
-            "asset": "101",
-            "source": [
-              "2012"
-            ]
-          },
-          {
-            "paraID": 1000,
-            "relayChain": "polkadot",
-            "nativeChainID": "statemint",
-            "symbol": "USDT",
-            "decimals": 6,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 1000
-              },
-              {
-                "palletInstance": 50
-              },
-              {
-                "generalIndex": 1984
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010300a10f043205011f",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 1000
-                    },
-                    {
-                      "palletInstance": 50
-                    },
-                    {
-                      "generalIndex": 1984
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "102",
-            "source": [
-              "2012"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "polkadot",
-            "nativeChainID": "acala",
-            "symbol": "ACA",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0000"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200411f06080000",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0000"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "108",
-            "source": [
-              "2012"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "polkadot",
-            "nativeChainID": "acala",
-            "symbol": "LDOT",
-            "decimals": 10,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0003"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200411f06080003",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0003"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "110",
-            "source": [
-              "2012"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "polkadot",
-            "nativeChainID": "acala",
-            "symbol": "lcDOT",
-            "decimals": 10,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x040d000000"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200411f0614040d000000",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x040d000000"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "106",
-            "source": [
-              "2012"
-            ]
-          },
-          {
-            "paraID": 2002,
-            "relayChain": "polkadot",
-            "nativeChainID": "clover",
-            "symbol": "CLV",
-            "decimals": 18,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2002
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010100491f",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2002
-                  }
-                }
-              }
-            },
-            "asset": "130",
-            "source": [
-              "2012"
-            ]
-          },
-          {
-            "paraID": 2004,
-            "relayChain": "polkadot",
-            "nativeChainID": "moonbeam",
-            "symbol": "GLMR",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2004
-              },
-              {
-                "palletInstance": 10
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200511f040a",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2004
-                    },
-                    {
-                      "palletInstance": 10
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "114",
-            "source": [
-              "2012"
-            ]
-          },
-          {
-            "paraID": 2012,
-            "relayChain": "polkadot",
-            "nativeChainID": "parallel",
-            "symbol": "sDOT",
-            "decimals": 10,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2012
-              },
-              {
-                "generalKey": "0x73444f54"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200711f061073444f54",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2012
-                    },
-                    {
-                      "generalKey": "0x73444f54"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "1001",
-            "source": [
-              "2012"
-            ]
-          },
-          {
-            "paraID": 2012,
-            "relayChain": "polkadot",
-            "nativeChainID": "parallel",
-            "symbol": "cDOT-8/15",
-            "decimals": 10,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2012
-              },
-              {
-                "palletInstance": 6
-              },
-              {
-                "generalIndex": 200080015
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010300711f0406053eeab32f",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 2012
-                    },
-                    {
-                      "palletInstance": 6
-                    },
-                    {
-                      "generalIndex": 200080015
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "200080015",
-            "source": [
-              "2012"
-            ]
-          },
-          {
-            "paraID": 2012,
-            "relayChain": "polkadot",
-            "nativeChainID": "parallel",
-            "symbol": "cDOT-9/16",
-            "decimals": 10,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2012
-              },
-              {
-                "palletInstance": 6
-              },
-              {
-                "generalIndex": 200090016
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010300711f0406058286b42f",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 2012
-                    },
-                    {
-                      "palletInstance": 6
-                    },
-                    {
-                      "generalIndex": 200090016
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "200090016",
-            "source": [
-              "2012"
-            ]
-          },
-          {
-            "paraID": 2012,
-            "relayChain": "polkadot",
-            "nativeChainID": "parallel",
-            "symbol": "cDOT-6/13",
-            "decimals": 10,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2012
-              },
-              {
-                "palletInstance": 6
-              },
-              {
-                "generalIndex": 200060013
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010300711f040605b6b1b22f",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 2012
-                    },
-                    {
-                      "palletInstance": 6
-                    },
-                    {
-                      "generalIndex": 200060013
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "200060013",
-            "source": [
-              "2012"
-            ]
-          },
-          {
-            "paraID": 2012,
-            "relayChain": "polkadot",
-            "nativeChainID": "parallel",
-            "symbol": "cDOT-10/17",
-            "decimals": 10,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2012
-              },
-              {
-                "palletInstance": 6
-              },
-              {
-                "generalIndex": 200100017
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010300711f040605c622b52f",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 2012
-                    },
-                    {
-                      "palletInstance": 6
-                    },
-                    {
-                      "generalIndex": 200100017
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "200100017",
-            "source": [
-              "2012"
-            ]
-          },
-          {
-            "paraID": 2012,
-            "relayChain": "polkadot",
-            "nativeChainID": "parallel",
-            "symbol": "cDOT-7/14",
-            "decimals": 10,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2012
-              },
-              {
-                "palletInstance": 6
-              },
-              {
-                "generalIndex": 200070014
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010300711f040605fa4db32f",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 2012
-                    },
-                    {
-                      "palletInstance": 6
-                    },
-                    {
-                      "generalIndex": 200070014
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "200070014",
-            "source": [
-              "2012"
-            ]
-          },
-          {
-            "paraID": 2032,
-            "relayChain": "polkadot",
-            "nativeChainID": "interlay",
-            "symbol": "IBTC",
-            "decimals": 8,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2032
-              },
-              {
-                "generalKey": "0x0001"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200c11f06080001",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2032
-                    },
-                    {
-                      "generalKey": "0x0001"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "122",
-            "source": [
-              "2012"
-            ]
-          },
-          {
-            "paraID": 2032,
-            "relayChain": "polkadot",
-            "nativeChainID": "interlay",
-            "symbol": "INTR",
-            "decimals": 10,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2032
-              },
-              {
-                "generalKey": "0x0002"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200c11f06080002",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2032
-                    },
-                    {
-                      "generalKey": "0x0002"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "120",
-            "source": [
-              "2012"
-            ]
-          },
-          {
-            "paraID": 2035,
-            "relayChain": "polkadot",
-            "nativeChainID": "phala",
-            "symbol": "PHA",
-            "decimals": 12,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2035
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010100cd1f",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2035
-                  }
-                }
-              }
-            },
-            "asset": "115",
-            "source": [
-              "2012"
-            ]
-          }
-        ]
-      },
-      {
-        "relayChain": "polkadot",
-        "paraID": 2030,
-        "id": "bifrost",
-        "xcAssetCnt": "9",
-        "data": [
-          {
-            "paraID": 0,
-            "relayChain": "polkadot",
-            "nativeChainID": "polkadot",
-            "symbol": "DOT",
-            "decimals": 10,
-            "interiorType": "here",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              "here"
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "here": null
-                }
-              }
-            },
-            "asset": {
-              "Token2": "0"
-            },
-            "source": [
-              "2030"
-            ]
-          },
-          {
-            "paraID": 1000,
-            "relayChain": "polkadot",
-            "nativeChainID": "statemint",
-            "symbol": "USDT",
-            "decimals": 6,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 1000
-              },
-              {
-                "palletInstance": 50
-              },
-              {
-                "generalIndex": 1984
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 1000
-                    },
-                    {
-                      "palletInstance": 50
-                    },
-                    {
-                      "generalIndex": 1984
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "Token2": "2"
-            },
-            "source": [
-              "2030"
-            ]
-          },
-          {
-            "paraID": 2004,
-            "relayChain": "polkadot",
-            "nativeChainID": "moonbeam",
-            "symbol": "GLMR",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2004
-              },
-              {
-                "palletInstance": 10
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2004
-                    },
-                    {
-                      "palletInstance": 10
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "Token2": "1"
-            },
-            "source": [
-              "2030"
-            ]
-          },
-          {
-            "paraID": 2006,
-            "relayChain": "polkadot",
-            "nativeChainID": "astar",
-            "symbol": "ASTR",
-            "decimals": 18,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2006
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2006
-                  }
-                }
-              }
-            },
-            "asset": {
-              "Token2": "3"
-            },
-            "source": [
-              "2030"
-            ]
-          },
-          {
-            "paraID": 2030,
-            "relayChain": "polkadot",
-            "nativeChainID": "bifrost",
-            "symbol": "vGLMR",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2030
-              },
-              {
-                "generalKey": "0x0901"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2030
-                    },
-                    {
-                      "generalKey": "0x0901"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "VToken2": "1"
-            },
-            "source": [
-              "2030"
-            ]
-          },
-          {
-            "paraID": 2030,
-            "relayChain": "polkadot",
-            "nativeChainID": "bifrost",
-            "symbol": "vFIL",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2030
-              },
-              {
-                "generalKey": "0x0904"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2030
-                    },
-                    {
-                      "generalKey": "0x0904"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "VToken2": "4"
-            },
-            "source": [
-              "2030"
-            ]
-          },
-          {
-            "paraID": 2030,
-            "relayChain": "polkadot",
-            "nativeChainID": "bifrost",
-            "symbol": "FIL",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2030
-              },
-              {
-                "generalKey": "0x0804"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2030
-                    },
-                    {
-                      "generalKey": "0x0804"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "Token2": "4"
-            },
-            "source": [
-              "2030"
-            ]
-          },
-          {
-            "paraID": 2030,
-            "relayChain": "polkadot",
-            "nativeChainID": "bifrost",
-            "symbol": "vDOT",
-            "decimals": 10,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2030
-              },
-              {
-                "generalKey": "0x0900"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2030
-                    },
-                    {
-                      "generalKey": "0x0900"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "VToken2": "0"
-            },
-            "source": [
-              "2030"
-            ]
-          },
-          {
-            "paraID": 2030,
-            "relayChain": "polkadot",
-            "nativeChainID": "bifrost",
-            "symbol": "vsDOT",
-            "decimals": 10,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2030
-              },
-              {
-                "generalKey": "0x0403"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2030
-                    },
-                    {
-                      "generalKey": "0x0403"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "VSToken2": "0"
-            },
-            "source": [
-              "2030"
-            ]
-          }
-        ]
-      },
-      {
-        "relayChain": "polkadot",
-        "paraID": 2031,
-        "id": "centrifuge",
-        "xcAssetCnt": "6",
-        "data": [
-          {
-            "paraID": 0,
-            "relayChain": "polkadot",
-            "nativeChainID": "polkadot",
-            "symbol": "DOT",
-            "decimals": 10,
-            "interiorType": "here",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              "here"
-            ],
-            "xcmV1MultiLocationByte": "0x0100",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "here": null
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "5"
-            },
-            "source": [
-              "2031"
-            ]
-          },
-          {
-            "paraID": 1000,
-            "relayChain": "polkadot",
-            "nativeChainID": "statemint",
-            "symbol": "USDT",
-            "decimals": 6,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 1000
-              },
-              {
-                "palletInstance": 50
-              },
-              {
-                "generalIndex": 1984
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010300a10f043205011f",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 1000
-                    },
-                    {
-                      "palletInstance": 50
-                    },
-                    {
-                      "generalIndex": 1984
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "1"
-            },
-            "source": [
-              "2031"
-            ]
-          },
-          {
-            "paraID": 1000,
-            "relayChain": "polkadot",
-            "nativeChainID": "statemint",
-            "symbol": "USDC",
-            "decimals": 6,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 1000
-              },
-              {
-                "palletInstance": 50
-              },
-              {
-                "generalIndex": 1337
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010300a10f043205e514",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 1000
-                    },
-                    {
-                      "palletInstance": 50
-                    },
-                    {
-                      "generalIndex": 1337
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "6"
-            },
-            "source": [
-              "2031"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "polkadot",
-            "nativeChainID": "acala",
-            "symbol": "aUSD",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0001"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200411f06080001",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0001"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "3"
-            },
-            "source": [
-              "2031"
-            ]
-          },
-          {
-            "paraID": 2004,
-            "relayChain": "polkadot",
-            "nativeChainID": "moonbeam",
-            "symbol": "GLMR",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2004
-              },
-              {
-                "palletInstance": 10
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200511f040a",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2004
-                    },
-                    {
-                      "palletInstance": 10
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "4"
-            },
-            "source": [
-              "2031"
-            ]
-          },
-          {
-            "paraID": 2031,
-            "relayChain": "polkadot",
-            "nativeChainID": "centrifuge",
-            "symbol": "CFG",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2031
-              },
-              {
-                "generalKey": "0x0001"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200bd1f06080001",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2031
-                    },
-                    {
-                      "generalKey": "0x0001"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "Native",
-            "source": [
-              "2031"
-            ]
-          }
-        ]
-      },
-      {
-        "relayChain": "polkadot",
-        "paraID": 2032,
-        "id": "interlay",
-        "xcAssetCnt": "2",
-        "data": [
-          {
-            "paraID": 1000,
-            "relayChain": "polkadot",
-            "nativeChainID": "statemint",
-            "symbol": "USDT",
-            "decimals": 6,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 1000
-              },
-              {
-                "palletInstance": 50
-              },
-              {
-                "generalIndex": 1984
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 1000
-                    },
-                    {
-                      "palletInstance": 50
-                    },
-                    {
-                      "generalIndex": 1984
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "2"
-            },
-            "source": [
-              "2032"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "polkadot",
-            "nativeChainID": "acala",
-            "symbol": "LDOT",
-            "decimals": 10,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0003"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0003"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "1"
-            },
-            "source": [
-              "2032"
-            ]
-          }
-        ]
-      },
-      {
-        "relayChain": "polkadot",
-        "paraID": 2034,
-        "id": "hydra",
-        "xcAssetCnt": "20",
-        "data": [
-          {
-            "paraID": 0,
-            "relayChain": "polkadot",
-            "nativeChainID": "polkadot",
-            "symbol": "DOT",
-            "decimals": 10,
-            "interiorType": "here",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              "here"
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "here": null
-                }
-              }
-            },
-            "asset": "5",
-            "source": [
-              "2034"
-            ]
-          },
-          {
-            "paraID": 1000,
-            "relayChain": "polkadot",
-            "nativeChainID": "statemint",
-            "symbol": "USDT",
-            "decimals": 6,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 1000
-              },
-              {
-                "palletInstance": 50
-              },
-              {
-                "generalIndex": 1984
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 1000
-                    },
-                    {
-                      "palletInstance": 50
-                    },
-                    {
-                      "generalIndex": 1984
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "10",
-            "source": [
-              "2034"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "polkadot",
-            "nativeChainID": "acala",
-            "symbol": "USDC",
-            "decimals": 6,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0207df96d1341a7d16ba1ad431e2c847d978bc2bce"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0207df96d1341a7d16ba1ad431e2c847d978bc2bce"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "7",
-            "source": [
-              "2034"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "polkadot",
-            "nativeChainID": "acala",
-            "symbol": "DAI",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0254a37a01cd75b616d63e0ab665bffdb0143c52ae"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0254a37a01cd75b616d63e0ab665bffdb0143c52ae"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "2",
-            "source": [
-              "2034"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "polkadot",
-            "nativeChainID": "acala",
-            "symbol": "APE",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x02f4c723e61709d90f89939c1852f516e373d418a8"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x02f4c723e61709d90f89939c1852f516e373d418a8"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "6",
-            "source": [
-              "2034"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "polkadot",
-            "nativeChainID": "acala",
-            "symbol": "WBTC",
-            "decimals": 8,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x02c80084af223c8b598536178d9361dc55bfda6818"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x02c80084af223c8b598536178d9361dc55bfda6818"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "3",
-            "source": [
-              "2034"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "polkadot",
-            "nativeChainID": "acala",
-            "symbol": "WETH",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x025a4d6acdc4e3e5ab15717f407afe957f7a242578"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x025a4d6acdc4e3e5ab15717f407afe957f7a242578"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "4",
-            "source": [
-              "2034"
-            ]
-          },
-          {
-            "paraID": 2004,
-            "relayChain": "polkadot",
-            "nativeChainID": "moonbeam",
-            "symbol": "WETH",
-            "decimals": 18,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2004
-              },
-              {
-                "palletInstance": 110
-              },
-              {
-                "accountKey20": {
-                  "network": null,
-                  "key": "0xab3f0245b83feb11d15aaffefd7ad465a59817ed"
-                }
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 2004
-                    },
-                    {
-                      "palletInstance": 110
-                    },
-                    {
-                      "accountKey20": {
-                        "network": null,
-                        "key": "0xab3f0245b83feb11d15aaffefd7ad465a59817ed"
-                      }
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "20",
-            "source": [
-              "2034"
-            ]
-          },
-          {
-            "paraID": 2004,
-            "relayChain": "polkadot",
-            "nativeChainID": "moonbeam",
-            "symbol": "WBTC",
-            "decimals": 8,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2004
-              },
-              {
-                "palletInstance": 110
-              },
-              {
-                "accountKey20": {
-                  "network": null,
-                  "key": "0xe57ebd2d67b462e9926e04a8e33f01cd0d64346d"
-                }
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 2004
-                    },
-                    {
-                      "palletInstance": 110
-                    },
-                    {
-                      "accountKey20": {
-                        "network": null,
-                        "key": "0xe57ebd2d67b462e9926e04a8e33f01cd0d64346d"
-                      }
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "19",
-            "source": [
-              "2034"
-            ]
-          },
-          {
-            "paraID": 2004,
-            "relayChain": "polkadot",
-            "nativeChainID": "moonbeam",
-            "symbol": "GLMR",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2004
-              },
-              {
-                "palletInstance": 10
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2004
-                    },
-                    {
-                      "palletInstance": 10
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "16",
-            "source": [
-              "2034"
-            ]
-          },
-          {
-            "paraID": 2004,
-            "relayChain": "polkadot",
-            "nativeChainID": "moonbeam",
-            "symbol": "USDC",
-            "decimals": 6,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2004
-              },
-              {
-                "palletInstance": 110
-              },
-              {
-                "accountKey20": {
-                  "network": null,
-                  "key": "0x931715fee2d06333043d11f658c8ce934ac61d0c"
-                }
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 2004
-                    },
-                    {
-                      "palletInstance": 110
-                    },
-                    {
-                      "accountKey20": {
-                        "network": null,
-                        "key": "0x931715fee2d06333043d11f658c8ce934ac61d0c"
-                      }
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "21",
-            "source": [
-              "2034"
-            ]
-          },
-          {
-            "paraID": 2004,
-            "relayChain": "polkadot",
-            "nativeChainID": "moonbeam",
-            "symbol": "DAI",
-            "decimals": 18,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2004
-              },
-              {
-                "palletInstance": 110
-              },
-              {
-                "accountKey20": {
-                  "network": null,
-                  "key": "0x06e605775296e851ff43b4daa541bb0984e9d6fd"
-                }
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 2004
-                    },
-                    {
-                      "palletInstance": 110
-                    },
-                    {
-                      "accountKey20": {
-                        "network": null,
-                        "key": "0x06e605775296e851ff43b4daa541bb0984e9d6fd"
-                      }
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "18",
-            "source": [
-              "2034"
-            ]
-          },
-          {
-            "paraID": 2006,
-            "relayChain": "polkadot",
-            "nativeChainID": "astar",
-            "symbol": "ASTR",
-            "decimals": 18,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2006
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2006
-                  }
-                }
-              }
-            },
-            "asset": "9",
-            "source": [
-              "2034"
-            ]
-          },
-          {
-            "paraID": 2030,
-            "relayChain": "polkadot",
-            "nativeChainID": "bifrost",
-            "symbol": "BNC",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2030
-              },
-              {
-                "generalKey": "0x0001"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2030
-                    },
-                    {
-                      "generalKey": "0x0001"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "14",
-            "source": [
-              "2034"
-            ]
-          },
-          {
-            "paraID": 2030,
-            "relayChain": "polkadot",
-            "nativeChainID": "bifrost",
-            "symbol": "vDOT",
-            "decimals": 10,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2030
-              },
-              {
-                "generalKey": "0x0900"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2030
-                    },
-                    {
-                      "generalKey": "0x0900"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "15",
-            "source": [
-              "2034"
-            ]
-          },
-          {
-            "paraID": 2031,
-            "relayChain": "polkadot",
-            "nativeChainID": "centrifuge",
-            "symbol": "CFG",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2031
-              },
-              {
-                "generalKey": "0x0001"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2031
-                    },
-                    {
-                      "generalKey": "0x0001"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "13",
-            "source": [
-              "2034"
-            ]
-          },
-          {
-            "paraID": 2032,
-            "relayChain": "polkadot",
-            "nativeChainID": "interlay",
-            "symbol": "iBTC",
-            "decimals": 8,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2032
-              },
-              {
-                "generalKey": "0x0001"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2032
-                    },
-                    {
-                      "generalKey": "0x0001"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "11",
-            "source": [
-              "2034"
-            ]
-          },
-          {
-            "paraID": 2032,
-            "relayChain": "polkadot",
-            "nativeChainID": "interlay",
-            "symbol": "INTR",
-            "decimals": 10,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2032
-              },
-              {
-                "generalKey": "0x0002"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2032
-                    },
-                    {
-                      "generalKey": "0x0002"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "17",
-            "source": [
-              "2034"
-            ]
-          },
-          {
-            "paraID": 2035,
-            "relayChain": "polkadot",
-            "nativeChainID": "phala",
-            "symbol": "PHA",
-            "decimals": 12,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2035
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2035
-                  }
-                }
-              }
-            },
-            "asset": "8",
-            "source": [
-              "2034"
-            ]
-          },
-          {
-            "paraID": 2092,
-            "relayChain": "polkadot",
-            "nativeChainID": "zeitgeist",
-            "symbol": "ZTG",
-            "decimals": 10,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2092
-              },
-              {
-                "generalKey": "0x0001"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2092
-                    },
-                    {
-                      "generalKey": "0x0001"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "12",
-            "source": [
-              "2034"
-            ]
-          }
-        ]
-      },
-      {
-        "relayChain": "polkadot",
-        "paraID": 2035,
-        "id": "phala",
-        "xcAssetCnt": "12",
-        "data": [
-          {
-            "paraID": 0,
-            "relayChain": "polkadot",
-            "nativeChainID": "polkadot",
-            "symbol": "DOT",
-            "decimals": 18,
-            "interiorType": "here",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              "here"
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "here": null
-                }
-              }
-            },
-            "asset": "0",
-            "source": [
-              "2035"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "polkadot",
-            "nativeChainID": "acala",
-            "symbol": "ACA",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0000"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0000"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "5",
-            "source": [
-              "2035"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "polkadot",
-            "nativeChainID": "acala",
-            "symbol": "AUSD",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0001"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0001"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "3",
-            "source": [
-              "2035"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "polkadot",
-            "nativeChainID": "acala",
-            "symbol": "LDOT",
-            "decimals": 10,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0003"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0003"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "4",
-            "source": [
-              "2035"
-            ]
-          },
-          {
-            "paraID": 2004,
-            "relayChain": "polkadot",
-            "nativeChainID": "moonbeam",
-            "symbol": "GLMR",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2004
-              },
-              {
-                "palletInstance": 10
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2004
-                    },
-                    {
-                      "palletInstance": 10
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "1",
-            "source": [
-              "2035"
-            ]
-          },
-          {
-            "paraID": 2006,
-            "relayChain": "polkadot",
-            "nativeChainID": "astar",
-            "symbol": "ASTR",
-            "decimals": 18,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2006
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2006
-                  }
-                }
-              }
-            },
-            "asset": "6",
-            "source": [
-              "2035"
-            ]
-          },
-          {
-            "paraID": 2011,
-            "relayChain": "polkadot",
-            "nativeChainID": "equilibrium",
-            "symbol": "EQ",
-            "decimals": 9,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2011
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2011
-                  }
-                }
-              }
-            },
-            "asset": "9",
-            "source": [
-              "2035"
-            ]
-          },
-          {
-            "paraID": 2011,
-            "relayChain": "polkadot",
-            "nativeChainID": "equilibrium",
-            "symbol": "EQD",
-            "decimals": 9,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2011
-              },
-              {
-                "generalKey": "0x657164"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2011
-                    },
-                    {
-                      "generalKey": "0x657164"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "10",
-            "source": [
-              "2035"
-            ]
-          },
-          {
-            "paraID": 2012,
-            "relayChain": "polkadot",
-            "nativeChainID": "parallel",
-            "symbol": "PARA",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2012
-              },
-              {
-                "generalKey": "0x50415241"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2012
-                    },
-                    {
-                      "generalKey": "0x50415241"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "2",
-            "source": [
-              "2035"
-            ]
-          },
-          {
-            "paraID": 2030,
-            "relayChain": "polkadot",
-            "nativeChainID": "bifrost",
-            "symbol": "BNC",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2030
-              },
-              {
-                "generalKey": "0x0001"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2030
-                    },
-                    {
-                      "generalKey": "0x0001"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "8",
-            "source": [
-              "2035"
-            ]
-          },
-          {
-            "paraID": 2034,
-            "relayChain": "polkadot",
-            "nativeChainID": "hydra",
-            "symbol": "HDX",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2034
-              },
-              {
-                "generalIndex": 0
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2034
-                    },
-                    {
-                      "generalIndex": 0
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "11",
-            "source": [
-              "2035"
-            ]
-          },
-          {
-            "paraID": 2046,
-            "relayChain": "polkadot",
-            "nativeChainID": "darwinia",
-            "symbol": "RING",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2046
-              },
-              {
-                "palletInstance": 5
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2046
-                    },
-                    {
-                      "palletInstance": 5
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "7",
-            "source": [
-              "2035"
-            ]
-          }
-        ]
-      },
-      {
-        "relayChain": "polkadot",
-        "paraID": 2043,
-        "id": "origintrail-parachain",
-        "xcAssetCnt": "1",
-        "data": [
-          {
-            "paraID": 2043,
-            "relayChain": "polkadot",
-            "nativeChainID": "origintrail-parachain",
-            "symbol": "TRAC",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "polkadot"
-              },
-              {
-                "parachain": 2043
-              },
-              {
-                "generalIndex": 1
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2043
-                    },
-                    {
-                      "generalIndex": 1
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "1",
-            "source": [
-              "2043"
-            ]
-          }
-        ]
-      }
-    ],
-    "kusama": [
-      {
-        "relayChain": "kusama",
-        "paraID": 2000,
-        "id": "karura",
-        "xcAssetCnt": "21",
-        "data": [
-          {
-            "paraID": 1000,
-            "relayChain": "kusama",
-            "nativeChainID": "statemine",
-            "symbol": "RMRK",
-            "decimals": 10,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 1000
-              },
-              {
-                "palletInstance": 50
-              },
-              {
-                "generalIndex": 8
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 1000
-                    },
-                    {
-                      "palletInstance": 50
-                    },
-                    {
-                      "generalIndex": 8
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "0"
-            },
-            "source": [
-              "2000"
-            ]
-          },
-          {
-            "paraID": 1000,
-            "relayChain": "kusama",
-            "nativeChainID": "statemine",
-            "symbol": "USDT",
-            "decimals": 6,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 1000
-              },
-              {
-                "palletInstance": 50
-              },
-              {
-                "generalIndex": 1984
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 1000
-                    },
-                    {
-                      "palletInstance": 50
-                    },
-                    {
-                      "generalIndex": 1984
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "7"
-            },
-            "source": [
-              "2000"
-            ]
-          },
-          {
-            "paraID": 1000,
-            "relayChain": "kusama",
-            "nativeChainID": "statemine",
-            "symbol": "ARIS",
-            "decimals": 8,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 1000
-              },
-              {
-                "palletInstance": 50
-              },
-              {
-                "generalIndex": 16
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 1000
-                    },
-                    {
-                      "palletInstance": 50
-                    },
-                    {
-                      "generalIndex": 16
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "1"
-            },
-            "source": [
-              "2000"
-            ]
-          },
-          {
-            "paraID": 2007,
-            "relayChain": "kusama",
-            "nativeChainID": "shiden",
-            "symbol": "SDN",
-            "decimals": 18,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2007
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2007
-                  }
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "18"
-            },
-            "source": [
-              "2000"
-            ]
-          },
-          {
-            "paraID": 2012,
-            "relayChain": "kusama",
-            "nativeChainID": "shadow",
-            "symbol": "CSM",
-            "decimals": 12,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2012
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2012
-                  }
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "5"
-            },
-            "source": [
-              "2000"
-            ]
-          },
-          {
-            "paraID": 2015,
-            "relayChain": "kusama",
-            "nativeChainID": "integritee",
-            "symbol": "TEER",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2015
-              },
-              {
-                "generalKey": "0x54454552"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2015
-                    },
-                    {
-                      "generalKey": "0x54454552"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "8"
-            },
-            "source": [
-              "2000"
-            ]
-          },
-          {
-            "paraID": 2023,
-            "relayChain": "kusama",
-            "nativeChainID": "moonriver",
-            "symbol": "MOVR",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2023
-              },
-              {
-                "palletInstance": 10
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2023
-                    },
-                    {
-                      "palletInstance": 10
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "3"
-            },
-            "source": [
-              "2000"
-            ]
-          },
-          {
-            "paraID": 2024,
-            "relayChain": "kusama",
-            "nativeChainID": null,
-            "symbol": "GENS",
-            "decimals": 9,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2024
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2024
-                  }
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "14"
-            },
-            "source": [
-              "2000"
-            ]
-          },
-          {
-            "paraID": 2024,
-            "relayChain": "kusama",
-            "nativeChainID": null,
-            "symbol": "EQD",
-            "decimals": 9,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2024
-              },
-              {
-                "generalKey": "0x657164"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2024
-                    },
-                    {
-                      "generalKey": "0x657164"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "15"
-            },
-            "source": [
-              "2000"
-            ]
-          },
-          {
-            "paraID": 2084,
-            "relayChain": "kusama",
-            "nativeChainID": "calamari",
-            "symbol": "KMA",
-            "decimals": 12,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2084
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2084
-                  }
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "10"
-            },
-            "source": [
-              "2000"
-            ]
-          },
-          {
-            "paraID": 2085,
-            "relayChain": "kusama",
-            "nativeChainID": "heiko",
-            "symbol": "HKO",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2085
-              },
-              {
-                "generalKey": "0x484b4f"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2085
-                    },
-                    {
-                      "generalKey": "0x484b4f"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "4"
-            },
-            "source": [
-              "2000"
-            ]
-          },
-          {
-            "paraID": 2088,
-            "relayChain": "kusama",
-            "nativeChainID": "altair",
-            "symbol": "AIR",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2088
-              },
-              {
-                "generalKey": "0x0001"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2088
-                    },
-                    {
-                      "generalKey": "0x0001"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "12"
-            },
-            "source": [
-              "2000"
-            ]
-          },
-          {
-            "paraID": 2090,
-            "relayChain": "kusama",
-            "nativeChainID": "basilisk",
-            "symbol": "BSX",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2090
-              },
-              {
-                "generalIndex": 0
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2090
-                    },
-                    {
-                      "generalIndex": 0
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "11"
-            },
-            "source": [
-              "2000"
-            ]
-          },
-          {
-            "paraID": 2095,
-            "relayChain": "kusama",
-            "nativeChainID": "quartz",
-            "symbol": "QTZ",
-            "decimals": 18,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2095
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2095
-                  }
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "2"
-            },
-            "source": [
-              "2000"
-            ]
-          },
-          {
-            "paraID": 2096,
-            "relayChain": "kusama",
-            "nativeChainID": "bitcountryPioneer",
-            "symbol": "NEER",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2096
-              },
-              {
-                "generalKey": "0x000000000000000000"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2096
-                    },
-                    {
-                      "generalKey": "0x000000000000000000"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "9"
-            },
-            "source": [
-              "2000"
-            ]
-          },
-          {
-            "paraID": 2102,
-            "relayChain": "kusama",
-            "nativeChainID": "pichiu",
-            "symbol": "PCHU",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2102
-              },
-              {
-                "generalKey": "0x50434855"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2102
-                    },
-                    {
-                      "generalKey": "0x50434855"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "17"
-            },
-            "source": [
-              "2000"
-            ]
-          },
-          {
-            "paraID": 2105,
-            "relayChain": "kusama",
-            "nativeChainID": "crab",
-            "symbol": "CRAB",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2105
-              },
-              {
-                "palletInstance": 5
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2105
-                    },
-                    {
-                      "palletInstance": 5
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "13"
-            },
-            "source": [
-              "2000"
-            ]
-          },
-          {
-            "paraID": 2106,
-            "relayChain": "kusama",
-            "nativeChainID": "litmus",
-            "symbol": "LIT",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2106
-              },
-              {
-                "palletInstance": 10
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2106
-                    },
-                    {
-                      "palletInstance": 10
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "20"
-            },
-            "source": [
-              "2000"
-            ]
-          },
-          {
-            "paraID": 2107,
-            "relayChain": "kusama",
-            "nativeChainID": null,
-            "symbol": "KICO",
-            "decimals": 14,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2107
-              },
-              {
-                "generalKey": "0x4b49434f"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2107
-                    },
-                    {
-                      "generalKey": "0x4b49434f"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "6"
-            },
-            "source": [
-              "2000"
-            ]
-          },
-          {
-            "paraID": 2114,
-            "relayChain": "kusama",
-            "nativeChainID": "turing",
-            "symbol": "TUR",
-            "decimals": 10,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2114
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2114
-                  }
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "16"
-            },
-            "source": [
-              "2000"
-            ]
-          },
-          {
-            "paraID": 2118,
-            "relayChain": "kusama",
-            "nativeChainID": null,
-            "symbol": "LT",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2118
-              },
-              {
-                "generalKey": "0x4c54"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2118
-                    },
-                    {
-                      "generalKey": "0x4c54"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "19"
-            },
-            "source": [
-              "2000"
-            ]
-          }
-        ]
-      },
-      {
-        "relayChain": "kusama",
-        "paraID": 2001,
-        "id": "bifrost",
-        "xcAssetCnt": "17",
-        "data": [
-          {
-            "paraID": 0,
-            "relayChain": "kusama",
-            "nativeChainID": "kusama",
-            "symbol": "KSM",
-            "decimals": 12,
-            "interiorType": "here",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              "here"
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "here": null
-                }
-              }
-            },
-            "asset": {
-              "Token": "KSM"
-            },
-            "source": [
-              "2001"
-            ]
-          },
-          {
-            "paraID": 1000,
-            "relayChain": "kusama",
-            "nativeChainID": "statemine",
-            "symbol": "RMRK",
-            "decimals": 10,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 1000
-              },
-              {
-                "palletInstance": 50
-              },
-              {
-                "generalIndex": 8
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 1000
-                    },
-                    {
-                      "palletInstance": 50
-                    },
-                    {
-                      "generalIndex": 8
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "Token": "RMRK"
-            },
-            "source": [
-              "2001"
-            ]
-          },
-          {
-            "paraID": 1000,
-            "relayChain": "kusama",
-            "nativeChainID": "statemine",
-            "symbol": "USDT",
-            "decimals": 6,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 1000
-              },
-              {
-                "palletInstance": 50
-              },
-              {
-                "generalIndex": 1984
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 1000
-                    },
-                    {
-                      "palletInstance": 50
-                    },
-                    {
-                      "generalIndex": 1984
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "Token2": "0"
-            },
-            "source": [
-              "2001"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "KUSD",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0081"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0081"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "Stable": "KUSD"
-            },
-            "source": [
-              "2001"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "KAR",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0080"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0080"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "Token": "KAR"
-            },
-            "source": [
-              "2001"
-            ]
-          },
-          {
-            "paraID": 2001,
-            "relayChain": "kusama",
-            "nativeChainID": "bifrost",
-            "symbol": "vBNC",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2001
-              },
-              {
-                "generalKey": "0x0101"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2001
-                    },
-                    {
-                      "generalKey": "0x0101"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "VToken": "BNC"
-            },
-            "source": [
-              "2001"
-            ]
-          },
-          {
-            "paraID": 2001,
-            "relayChain": "kusama",
-            "nativeChainID": "bifrost",
-            "symbol": "vMOVR",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2001
-              },
-              {
-                "generalKey": "0x010a"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2001
-                    },
-                    {
-                      "generalKey": "0x010a"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "VToken": "MOVR"
-            },
-            "source": [
-              "2001"
-            ]
-          },
-          {
-            "paraID": 2001,
-            "relayChain": "kusama",
-            "nativeChainID": "bifrost",
-            "symbol": "vKSM",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2001
-              },
-              {
-                "generalKey": "0x0104"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2001
-                    },
-                    {
-                      "generalKey": "0x0104"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "VToken": "KSM"
-            },
-            "source": [
-              "2001"
-            ]
-          },
-          {
-            "paraID": 2001,
-            "relayChain": "kusama",
-            "nativeChainID": "bifrost",
-            "symbol": "ZLK",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2001
-              },
-              {
-                "generalKey": "0x0207"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2001
-                    },
-                    {
-                      "generalKey": "0x0207"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "Token": "ZLK"
-            },
-            "source": [
-              "2001"
-            ]
-          },
-          {
-            "paraID": 2001,
-            "relayChain": "kusama",
-            "nativeChainID": "bifrost",
-            "symbol": "VSvsKSM",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2001
-              },
-              {
-                "generalKey": "0x0404"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2001
-                    },
-                    {
-                      "generalKey": "0x0404"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "VSToken": "KSM"
-            },
-            "source": [
-              "2001"
-            ]
-          },
-          {
-            "paraID": 2001,
-            "relayChain": "kusama",
-            "nativeChainID": "bifrost",
-            "symbol": "BNC",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2001
-              },
-              {
-                "generalKey": "0x0001"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2001
-                    },
-                    {
-                      "generalKey": "0x0001"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "Native": "BNC"
-            },
-            "source": [
-              "2001"
-            ]
-          },
-          {
-            "paraID": 2004,
-            "relayChain": "kusama",
-            "nativeChainID": "khala",
-            "symbol": "PHA",
-            "decimals": 12,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2004
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2004
-                  }
-                }
-              }
-            },
-            "asset": {
-              "Token": "PHA"
-            },
-            "source": [
-              "2001"
-            ]
-          },
-          {
-            "paraID": 2007,
-            "relayChain": "kusama",
-            "nativeChainID": "shiden",
-            "symbol": "SDN",
-            "decimals": 18,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2007
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2007
-                  }
-                }
-              }
-            },
-            "asset": {
-              "Token2": "3"
-            },
-            "source": [
-              "2001"
-            ]
-          },
-          {
-            "paraID": 2023,
-            "relayChain": "kusama",
-            "nativeChainID": "moonriver",
-            "symbol": "MOVR",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2023
-              },
-              {
-                "palletInstance": 10
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2023
-                    },
-                    {
-                      "palletInstance": 10
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "Token": "MOVR"
-            },
-            "source": [
-              "2001"
-            ]
-          },
-          {
-            "paraID": 2092,
-            "relayChain": "kusama",
-            "nativeChainID": "kintsugi",
-            "symbol": "KBTC",
-            "decimals": 8,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2092
-              },
-              {
-                "generalKey": "0x000b"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2092
-                    },
-                    {
-                      "generalKey": "0x000b"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "Token2": "2"
-            },
-            "source": [
-              "2001"
-            ]
-          },
-          {
-            "paraID": 2092,
-            "relayChain": "kusama",
-            "nativeChainID": "kintsugi",
-            "symbol": "KINT",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2092
-              },
-              {
-                "generalKey": "0x000c"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2092
-                    },
-                    {
-                      "generalKey": "0x000c"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "Token2": "1"
-            },
-            "source": [
-              "2001"
-            ]
-          },
-          {
-            "paraID": 2110,
-            "relayChain": "kusama",
-            "nativeChainID": "mangata",
-            "symbol": "MGX",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2110
-              },
-              {
-                "generalKey": "0x00000000"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2110
-                    },
-                    {
-                      "generalKey": "0x00000000"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "Token2": "4"
-            },
-            "source": [
-              "2001"
-            ]
-          }
-        ]
-      },
-      {
-        "relayChain": "kusama",
-        "paraID": 2004,
-        "id": "khala",
-        "xcAssetCnt": "16",
-        "data": [
-          {
-            "paraID": 0,
-            "relayChain": "kusama",
-            "nativeChainID": "kusama",
-            "symbol": "KSM",
-            "decimals": 12,
-            "interiorType": "here",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              "here"
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "here": null
-                }
-              }
-            },
-            "asset": "0",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "KAR",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0080"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0080"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "1",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "aUSD",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0081"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0081"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "4",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2001,
-            "relayChain": "kusama",
-            "nativeChainID": "bifrost",
-            "symbol": "BNC",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2001
-              },
-              {
-                "generalKey": "0x0001"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2001
-                    },
-                    {
-                      "generalKey": "0x0001"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "2",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2001,
-            "relayChain": "kusama",
-            "nativeChainID": "bifrost",
-            "symbol": "ZLK",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2001
-              },
-              {
-                "generalKey": "0x0207"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2001
-                    },
-                    {
-                      "generalKey": "0x0207"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "3",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2007,
-            "relayChain": "kusama",
-            "nativeChainID": "shiden",
-            "symbol": "SDN",
-            "decimals": 18,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2007
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2007
-                  }
-                }
-              }
-            },
-            "asset": "12",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2023,
-            "relayChain": "kusama",
-            "nativeChainID": "moonriver",
-            "symbol": "MOVR",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2023
-              },
-              {
-                "palletInstance": 10
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2023
-                    },
-                    {
-                      "palletInstance": 10
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "6",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2084,
-            "relayChain": "kusama",
-            "nativeChainID": "calamari",
-            "symbol": "KMA",
-            "decimals": 12,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2084
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2084
-                  }
-                }
-              }
-            },
-            "asset": "8",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2085,
-            "relayChain": "kusama",
-            "nativeChainID": "heiko",
-            "symbol": "HKO",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2085
-              },
-              {
-                "generalKey": "0x484b4f"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2085
-                    },
-                    {
-                      "generalKey": "0x484b4f"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "7",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2087,
-            "relayChain": "kusama",
-            "nativeChainID": "picasso",
-            "symbol": "PICA",
-            "decimals": 12,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2087
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2087
-                  }
-                }
-              }
-            },
-            "asset": "15",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2090,
-            "relayChain": "kusama",
-            "nativeChainID": "basilisk",
-            "symbol": "BSX",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2090
-              },
-              {
-                "generalKey": "0x00000000"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2090
-                    },
-                    {
-                      "generalKey": "0x00000000"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "5",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2090,
-            "relayChain": "kusama",
-            "nativeChainID": "basilisk",
-            "symbol": "BSX",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2090
-              },
-              {
-                "generalIndex": 0
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2090
-                    },
-                    {
-                      "generalIndex": 0
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "9",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2096,
-            "relayChain": "kusama",
-            "nativeChainID": "bitcountryPioneer",
-            "symbol": "NEER",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2096
-              },
-              {
-                "generalKey": "0x000000000000000000"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2096
-                    },
-                    {
-                      "generalKey": "0x000000000000000000"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "13",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2096,
-            "relayChain": "kusama",
-            "nativeChainID": "bitcountryPioneer",
-            "symbol": "BIT",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2096
-              },
-              {
-                "generalKey": "0x020000000000000000"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2096
-                    },
-                    {
-                      "generalKey": "0x020000000000000000"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "14",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2105,
-            "relayChain": "kusama",
-            "nativeChainID": "crab",
-            "symbol": "CRAB",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2105
-              },
-              {
-                "palletInstance": 5
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2105
-                    },
-                    {
-                      "palletInstance": 5
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "11",
-            "source": [
-              "2004"
-            ]
-          },
-          {
-            "paraID": 2114,
-            "relayChain": "kusama",
-            "nativeChainID": "turing",
-            "symbol": "TUR",
-            "decimals": 10,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2114
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2114
-                  }
-                }
-              }
-            },
-            "asset": "10",
-            "source": [
-              "2004"
-            ]
-          }
-        ]
-      },
-      {
-        "relayChain": "kusama",
-        "paraID": 2007,
-        "id": "shiden",
-        "xcAssetCnt": "19",
-        "data": [
-          {
-            "paraID": 0,
-            "relayChain": "kusama",
-            "nativeChainID": "kusama",
-            "symbol": "KSM",
-            "decimals": 12,
-            "interiorType": "here",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              "here"
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "here": null
-                }
-              }
-            },
-            "asset": "340282366920938463463374607431768211455",
-            "contractAddress": "0xffffffffffffffffffffffffffffffffffffffff",
-            "source": [
-              "2007"
-            ]
-          },
-          {
-            "paraID": 1000,
-            "relayChain": "kusama",
-            "nativeChainID": "statemine",
-            "symbol": "USDT",
-            "decimals": 6,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 1000
-              },
-              {
-                "palletInstance": 50
-              },
-              {
-                "generalIndex": 1984
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 1000
-                    },
-                    {
-                      "palletInstance": 50
-                    },
-                    {
-                      "generalIndex": 1984
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "4294969280",
-            "contractAddress": "0xffffffff000000000000000000000001000007c0",
-            "source": [
-              "2007"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "KAR",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0080"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0080"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "18446744073709551618",
-            "contractAddress": "0xffffffff00000000000000010000000000000002",
-            "source": [
-              "2007"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "LKSM",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0083"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0083"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "18446744073709551619",
-            "contractAddress": "0xffffffff00000000000000010000000000000003",
-            "source": [
-              "2007"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "aSEED",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0081"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0081"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "18446744073709551616",
-            "contractAddress": "0xffffffff00000000000000010000000000000000",
-            "source": [
-              "2007"
-            ]
-          },
-          {
-            "paraID": 2001,
-            "relayChain": "kusama",
-            "nativeChainID": "bifrost",
-            "symbol": "BNC",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2001
-              },
-              {
-                "generalKey": "0x0001"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2001
-                    },
-                    {
-                      "generalKey": "0x0001"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "18446744073709551627",
-            "contractAddress": "0xffffffff0000000000000001000000000000000b",
-            "source": [
-              "2007"
-            ]
-          },
-          {
-            "paraID": 2001,
-            "relayChain": "kusama",
-            "nativeChainID": "bifrost",
-            "symbol": "vsKSM",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2001
-              },
-              {
-                "generalKey": "0x0404"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2001
-                    },
-                    {
-                      "generalKey": "0x0404"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "18446744073709551629",
-            "contractAddress": "0xffffffff0000000000000001000000000000000d",
-            "source": [
-              "2007"
-            ]
-          },
-          {
-            "paraID": 2001,
-            "relayChain": "kusama",
-            "nativeChainID": "bifrost",
-            "symbol": "vKSM",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2001
-              },
-              {
-                "generalKey": "0x0104"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2001
-                    },
-                    {
-                      "generalKey": "0x0104"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "18446744073709551628",
-            "contractAddress": "0xffffffff0000000000000001000000000000000c",
-            "source": [
-              "2007"
-            ]
-          },
-          {
-            "paraID": 2004,
-            "relayChain": "kusama",
-            "nativeChainID": "khala",
-            "symbol": "PHA",
-            "decimals": 12,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2004
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2004
-                  }
-                }
-              }
-            },
-            "asset": "18446744073709551623",
-            "contractAddress": "0xffffffff00000000000000010000000000000007",
-            "source": [
-              "2007"
-            ]
-          },
-          {
-            "paraID": 2012,
-            "relayChain": "kusama",
-            "nativeChainID": "shadow",
-            "symbol": "CSM",
-            "decimals": 12,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2012
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2012
-                  }
-                }
-              }
-            },
-            "asset": "18446744073709551624",
-            "contractAddress": "0xffffffff00000000000000010000000000000008",
-            "source": [
-              "2007"
-            ]
-          },
-          {
-            "paraID": 2016,
-            "relayChain": "kusama",
-            "nativeChainID": null,
-            "symbol": "SKU",
-            "decimals": 18,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2016
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2016
-                  }
-                }
-              }
-            },
-            "asset": "18446744073709551626",
-            "contractAddress": "0xffffffff0000000000000001000000000000000a",
-            "source": [
-              "2007"
-            ]
-          },
-          {
-            "paraID": 2023,
-            "relayChain": "kusama",
-            "nativeChainID": "moonriver",
-            "symbol": "MOVR",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2023
-              },
-              {
-                "palletInstance": 10
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2023
-                    },
-                    {
-                      "palletInstance": 10
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "18446744073709551620",
-            "contractAddress": "0xffffffff00000000000000010000000000000004",
-            "source": [
-              "2007"
-            ]
-          },
-          {
-            "paraID": 2024,
-            "relayChain": "kusama",
-            "nativeChainID": null,
-            "symbol": "GENS",
-            "decimals": 9,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2024
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2024
-                  }
-                }
-              }
-            },
-            "asset": "18446744073709551630",
-            "contractAddress": "0xffffffff0000000000000001000000000000000e",
-            "source": [
-              "2007"
-            ]
-          },
-          {
-            "paraID": 2024,
-            "relayChain": "kusama",
-            "nativeChainID": null,
-            "symbol": "EQD",
-            "decimals": 9,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2024
-              },
-              {
-                "generalKey": "0x657164"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2024
-                    },
-                    {
-                      "generalKey": "0x657164"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "18446744073709551631",
-            "contractAddress": "0xffffffff0000000000000001000000000000000f",
-            "source": [
-              "2007"
-            ]
-          },
-          {
-            "paraID": 2092,
-            "relayChain": "kusama",
-            "nativeChainID": "kintsugi",
-            "symbol": "KBTC",
-            "decimals": 8,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2092
-              },
-              {
-                "generalKey": "0x000b"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2092
-                    },
-                    {
-                      "generalKey": "0x000b"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "18446744073709551621",
-            "contractAddress": "0xffffffff00000000000000010000000000000005",
-            "source": [
-              "2007"
-            ]
-          },
-          {
-            "paraID": 2092,
-            "relayChain": "kusama",
-            "nativeChainID": "kintsugi",
-            "symbol": "KINT",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2092
-              },
-              {
-                "generalKey": "0x000c"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2092
-                    },
-                    {
-                      "generalKey": "0x000c"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "18446744073709551622",
-            "contractAddress": "0xffffffff00000000000000010000000000000006",
-            "source": [
-              "2007"
-            ]
-          },
-          {
-            "paraID": 2095,
-            "relayChain": "kusama",
-            "nativeChainID": "quartz",
-            "symbol": "QTZ",
-            "decimals": 18,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2095
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2095
-                  }
-                }
-              }
-            },
-            "asset": "18446744073709551633",
-            "contractAddress": "0xffffffff00000000000000010000000000000011",
-            "source": [
-              "2007"
-            ]
-          },
-          {
-            "paraID": 2096,
-            "relayChain": "kusama",
-            "nativeChainID": "bitcountryPioneer",
-            "symbol": "NEER",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2096
-              },
-              {
-                "generalKey": "0x000000000000000000"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2096
-                    },
-                    {
-                      "generalKey": "0x000000000000000000"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "18446744073709551632",
-            "contractAddress": "0xffffffff00000000000000010000000000000010",
-            "source": [
-              "2007"
-            ]
-          },
-          {
-            "paraID": 2105,
-            "relayChain": "kusama",
-            "nativeChainID": "crab",
-            "symbol": "CRAB",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2105
-              },
-              {
-                "palletInstance": 5
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2105
-                    },
-                    {
-                      "palletInstance": 5
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "18446744073709551625",
-            "contractAddress": "0xffffffff00000000000000010000000000000009",
-            "source": [
-              "2007"
-            ]
-          }
-        ]
-      },
-      {
-        "relayChain": "kusama",
-        "paraID": 2012,
-        "id": "shadow",
-        "xcAssetCnt": "7",
-        "data": [
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "KAR",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0080"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200411f06080080",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0080"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "10810581592933651521121702237638664357",
-            "source": [
-              "2012"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "AUSD",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0081"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200411f06080081",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0081"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "214920334981412447805621250067209749032",
-            "source": [
-              "2012"
-            ]
-          },
-          {
-            "paraID": 2001,
-            "relayChain": "kusama",
-            "nativeChainID": "bifrost",
-            "symbol": "BNC",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2001
-              },
-              {
-                "generalKey": "0x0001"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200451f06080001",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2001
-                    },
-                    {
-                      "generalKey": "0x0001"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "319623561105283008236062145480775032445",
-            "source": [
-              "2012"
-            ]
-          },
-          {
-            "paraID": 2007,
-            "relayChain": "kusama",
-            "nativeChainID": "shiden",
-            "symbol": "SDN",
-            "decimals": 18,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2007
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x0101005d1f",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2007
-                  }
-                }
-              }
-            },
-            "asset": "16797826370226091782818345603793389938",
-            "source": [
-              "2012"
-            ]
-          },
-          {
-            "paraID": 2023,
-            "relayChain": "kusama",
-            "nativeChainID": "moonriver",
-            "symbol": "MOVR",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2023
-              },
-              {
-                "palletInstance": 10
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x0102009d1f040a",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2023
-                    },
-                    {
-                      "palletInstance": 10
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "232263652204149413431520870009560565298",
-            "source": [
-              "2012"
-            ]
-          },
-          {
-            "paraID": 2048,
-            "relayChain": "kusama",
-            "nativeChainID": "robonomics",
-            "symbol": "XRT",
-            "decimals": 9,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2048
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x0101000120",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2048
-                  }
-                }
-              }
-            },
-            "asset": "108036400430056508975016746969135344601",
-            "source": [
-              "2012"
-            ]
-          },
-          {
-            "paraID": 2105,
-            "relayChain": "kusama",
-            "nativeChainID": "crab",
-            "symbol": "CRAB",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2105
-              },
-              {
-                "palletInstance": 5
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200e5200405",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2105
-                    },
-                    {
-                      "palletInstance": 5
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "173481220575862801646329923366065693029",
-            "source": [
-              "2012"
-            ]
-          }
-        ]
-      },
-      {
-        "relayChain": "kusama",
-        "paraID": 2023,
-        "id": "moonriver",
-        "xcAssetCnt": "22",
-        "data": [
-          {
-            "paraID": 0,
-            "relayChain": "kusama",
-            "nativeChainID": "kusama",
-            "symbol": "KSM",
-            "decimals": 12,
-            "interiorType": "here",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              "here"
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "here": null
-                }
-              }
-            },
-            "asset": "42259045809535163221576417993425387648",
-            "contractAddress": "0xffffffff1fcacbd218edc0eba20fc2308c778080",
-            "source": [
-              "2023"
-            ]
-          },
-          {
-            "paraID": 1000,
-            "relayChain": "kusama",
-            "nativeChainID": "statemine",
-            "symbol": "USDT",
-            "decimals": 6,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 1000
-              },
-              {
-                "palletInstance": 50
-              },
-              {
-                "generalIndex": 1984
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 1000
-                    },
-                    {
-                      "palletInstance": 50
-                    },
-                    {
-                      "generalIndex": 1984
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "311091173110107856861649819128533077277",
-            "contractAddress": "0xffffffffea09fb06d082fd1275cd48b191cbcd1d",
-            "source": [
-              "2023"
-            ]
-          },
-          {
-            "paraID": 1000,
-            "relayChain": "kusama",
-            "nativeChainID": "statemine",
-            "symbol": "RMRK",
-            "decimals": 10,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 1000
-              },
-              {
-                "palletInstance": 50
-              },
-              {
-                "generalIndex": 8
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 1000
-                    },
-                    {
-                      "palletInstance": 50
-                    },
-                    {
-                      "generalIndex": 8
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "182365888117048807484804376330534607370",
-            "contractAddress": "0xffffffff893264794d9d57e1e0e21e0042af5a0a",
-            "source": [
-              "2023"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "aSeed",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0081"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0081"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "214920334981412447805621250067209749032",
-            "contractAddress": "0xffffffffa1b026a00fbaa67c86d5d1d5bf8d8228",
-            "source": [
-              "2023"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "KAR",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0080"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0080"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "10810581592933651521121702237638664357",
-            "contractAddress": "0xffffffff08220ad2e6e157f26ed8bd22a336a0a5",
-            "source": [
-              "2023"
-            ]
-          },
-          {
-            "paraID": 2001,
-            "relayChain": "kusama",
-            "nativeChainID": "bifrost",
-            "symbol": "vKSM",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2001
-              },
-              {
-                "generalKey": "0x0104"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2001
-                    },
-                    {
-                      "generalKey": "0x0104"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "264344629840762281112027368930249420542",
-            "contractAddress": "0xffffffffc6deec7fc8b11a2c8dde9a59f8c62efe",
-            "source": [
-              "2023"
-            ]
-          },
-          {
-            "paraID": 2001,
-            "relayChain": "kusama",
-            "nativeChainID": "bifrost",
-            "symbol": "vBNC",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2001
-              },
-              {
-                "generalKey": "0x0101"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2001
-                    },
-                    {
-                      "generalKey": "0x0101"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "72145018963825376852137222787619937732",
-            "contractAddress": "0xffffffff3646a00f78cadf8883c5a2791bfcddc4",
-            "source": [
-              "2023"
-            ]
-          },
-          {
-            "paraID": 2001,
-            "relayChain": "kusama",
-            "nativeChainID": "bifrost",
-            "symbol": "vMOVR",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2001
-              },
-              {
-                "generalKey": "0x010a"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2001
-                    },
-                    {
-                      "generalKey": "0x010a"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "203223821023327994093278529517083736593",
-            "contractAddress": "0xffffffff98e37bf6a393504b5adc5b53b4d0ba11",
-            "source": [
-              "2023"
-            ]
-          },
-          {
-            "paraID": 2001,
-            "relayChain": "kusama",
-            "nativeChainID": "bifrost",
-            "symbol": "BNC",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2001
-              },
-              {
-                "generalKey": "0x0001"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2001
-                    },
-                    {
-                      "generalKey": "0x0001"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "319623561105283008236062145480775032445",
-            "contractAddress": "0xfffffffff075423be54811ecb478e911f22dde7d",
-            "source": [
-              "2023"
-            ]
-          },
-          {
-            "paraID": 2004,
-            "relayChain": "kusama",
-            "nativeChainID": "khala",
-            "symbol": "PHA",
-            "decimals": 12,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2004
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2004
-                  }
-                }
-              }
-            },
-            "asset": "189307976387032586987344677431204943363",
-            "contractAddress": "0xffffffff8e6b63d9e447b6d4c45bda8af9dc9603",
-            "source": [
-              "2023"
-            ]
-          },
-          {
-            "paraID": 2007,
-            "relayChain": "kusama",
-            "nativeChainID": "shiden",
-            "symbol": "SDN",
-            "decimals": 18,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2007
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2007
-                  }
-                }
-              }
-            },
-            "asset": "16797826370226091782818345603793389938",
-            "contractAddress": "0xffffffff0ca324c842330521525e7de111f38972",
-            "source": [
-              "2023"
-            ]
-          },
-          {
-            "paraID": 2012,
-            "relayChain": "kusama",
-            "nativeChainID": "shadow",
-            "symbol": "CSM",
-            "decimals": 12,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2012
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2012
-                  }
-                }
-              }
-            },
-            "asset": "108457044225666871745333730479173774551",
-            "contractAddress": "0xffffffff519811215e05efa24830eebe9c43acd7",
-            "source": [
-              "2023"
-            ]
-          },
-          {
-            "paraID": 2015,
-            "relayChain": "kusama",
-            "nativeChainID": "integritee",
-            "symbol": "TEER",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2015
-              },
-              {
-                "generalKey": "0x54454552"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2015
-                    },
-                    {
-                      "generalKey": "0x54454552"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "105075627293246237499203909093923548958",
-            "contractAddress": "0xffffffff4f0cd46769550e5938f6bee2f5d4ef1e",
-            "source": [
-              "2023"
-            ]
-          },
-          {
-            "paraID": 2048,
-            "relayChain": "kusama",
-            "nativeChainID": "robonomics",
-            "symbol": "XRT",
-            "decimals": 9,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2048
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2048
-                  }
-                }
-              }
-            },
-            "asset": "108036400430056508975016746969135344601",
-            "contractAddress": "0xffffffff51470dca3dbe535bd2880a9ccdbc6bd9",
-            "source": [
-              "2023"
-            ]
-          },
-          {
-            "paraID": 2084,
-            "relayChain": "kusama",
-            "nativeChainID": "calamari",
-            "symbol": "KMA",
-            "decimals": 12,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2084
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2084
-                  }
-                }
-              }
-            },
-            "asset": "213357169630950964874127107356898319277",
-            "contractAddress": "0xffffffffa083189f870640b141ae1e882c2b5bad",
-            "source": [
-              "2023"
-            ]
-          },
-          {
-            "paraID": 2085,
-            "relayChain": "kusama",
-            "nativeChainID": "heiko",
-            "symbol": "HKO",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2085
-              },
-              {
-                "generalKey": "0x484b4f"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2085
-                    },
-                    {
-                      "generalKey": "0x484b4f"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "76100021443485661246318545281171740067",
-            "contractAddress": "0xffffffff394054bcda1902b6a6436840435655a3",
-            "source": [
-              "2023"
-            ]
-          },
-          {
-            "paraID": 2092,
-            "relayChain": "kusama",
-            "nativeChainID": "kintsugi",
-            "symbol": "KBTC",
-            "decimals": 8,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2092
-              },
-              {
-                "generalKey": "0x000b"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2092
-                    },
-                    {
-                      "generalKey": "0x000b"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "328179947973504579459046439826496046832",
-            "contractAddress": "0xfffffffff6e528ad57184579beee00c5d5e646f0",
-            "source": [
-              "2023"
-            ]
-          },
-          {
-            "paraID": 2092,
-            "relayChain": "kusama",
-            "nativeChainID": "kintsugi",
-            "symbol": "KINT",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2092
-              },
-              {
-                "generalKey": "0x000c"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2092
-                    },
-                    {
-                      "generalKey": "0x000c"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "175400718394635817552109270754364440562",
-            "contractAddress": "0xffffffff83f4f317d3cbf6ec6250aec3697b3ff2",
-            "source": [
-              "2023"
-            ]
-          },
-          {
-            "paraID": 2105,
-            "relayChain": "kusama",
-            "nativeChainID": "crab",
-            "symbol": "CRAB",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2105
-              },
-              {
-                "palletInstance": 5
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2105
-                    },
-                    {
-                      "palletInstance": 5
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "173481220575862801646329923366065693029",
-            "contractAddress": "0xffffffff8283448b3cb519ca4732f2dddc6a6165",
-            "source": [
-              "2023"
-            ]
-          },
-          {
-            "paraID": 2106,
-            "relayChain": "kusama",
-            "nativeChainID": "litmus",
-            "symbol": "LIT",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2106
-              },
-              {
-                "palletInstance": 10
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2106
-                    },
-                    {
-                      "palletInstance": 10
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "65216491554813189869575508812319036608",
-            "contractAddress": "0xffffffff31103d490325bb0a8e40ef62e2f614c0",
-            "source": [
-              "2023"
-            ]
-          },
-          {
-            "paraID": 2110,
-            "relayChain": "kusama",
-            "nativeChainID": "mangata",
-            "symbol": "MGX",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2110
-              },
-              {
-                "generalKey": "0x00000000"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2110
-                    },
-                    {
-                      "generalKey": "0x00000000"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "118095707745084482624853002839493125353",
-            "contractAddress": "0xffffffff58d867eea1ce5126a4769542116324e9",
-            "source": [
-              "2023"
-            ]
-          },
-          {
-            "paraID": 2114,
-            "relayChain": "kusama",
-            "nativeChainID": "turing",
-            "symbol": "TUR",
-            "decimals": 10,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2114
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2114
-                  }
-                }
-              }
-            },
-            "asset": "133300872918374599700079037156071917454",
-            "contractAddress": "0xffffffff6448d0746f2a66342b67ef9caf89478e",
-            "source": [
-              "2023"
-            ]
-          }
-        ]
-      },
-      {
-        "relayChain": "kusama",
-        "paraID": 2084,
-        "id": "calamari",
-        "xcAssetCnt": "20",
-        "data": [
-          {
-            "paraID": 0,
-            "relayChain": "kusama",
-            "nativeChainID": "kusama",
-            "symbol": "KSM",
-            "decimals": 12,
-            "interiorType": "here",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              "here"
-            ],
-            "xcmV1MultiLocationByte": "0x0100",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "here": null
-                }
-              }
-            },
-            "asset": "12",
-            "source": [
-              "2084"
-            ]
-          },
-          {
-            "paraID": 1000,
-            "relayChain": "kusama",
-            "nativeChainID": "statemine",
-            "symbol": "USDT",
-            "decimals": 6,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 1000
-              },
-              {
-                "palletInstance": 50
-              },
-              {
-                "generalIndex": 1984
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010300a10f043205011f",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 1000
-                    },
-                    {
-                      "palletInstance": 50
-                    },
-                    {
-                      "generalIndex": 1984
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "14",
-            "source": [
-              "2084"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "KAR",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0080"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200411f06080080",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0080"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "8",
-            "source": [
-              "2084"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "AUSD",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0081"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200411f06080081",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0081"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "9",
-            "source": [
-              "2084"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "LKSM",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0083"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200411f06080083",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0083"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "10",
-            "source": [
-              "2084"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "USDC",
-            "decimals": 6,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x021f3a10587a20114ea25ba1b388ee2dd4a337ce27"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200411f0654021f3a10587a20114ea25ba1b388ee2dd4a337ce27",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x021f3a10587a20114ea25ba1b388ee2dd4a337ce27"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "16",
-            "source": [
-              "2084"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "LINK",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x022c7de70b32cf5f20e02329a88d2e3b00ef85eb90"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200411f0654022c7de70b32cf5f20e02329a88d2e3b00ef85eb90",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x022c7de70b32cf5f20e02329a88d2e3b00ef85eb90"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "24",
-            "source": [
-              "2084"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "APE",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0230b1f4ba0b07789be9986fa090a57e0fe5631ebb"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200411f06540230b1f4ba0b07789be9986fa090a57e0fe5631ebb",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0230b1f4ba0b07789be9986fa090a57e0fe5631ebb"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "25",
-            "source": [
-              "2084"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "DAI",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x024bb6afb5fa2b07a5d1c499e1c3ddb5a15e709a71"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200411f0654024bb6afb5fa2b07a5d1c499e1c3ddb5a15e709a71",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x024bb6afb5fa2b07a5d1c499e1c3ddb5a15e709a71"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "15",
-            "source": [
-              "2084"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "BUSD",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x02577f6a0718a468e8a995f6075f2325f86a07c83b"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200411f065402577f6a0718a468e8a995f6075f2325f86a07c83b",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x02577f6a0718a468e8a995f6075f2325f86a07c83b"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "23",
-            "source": [
-              "2084"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "WBTC",
-            "decimals": 8,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0266291c7d88d2ed9a708147bae4e0814a76705e2f"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200411f06540266291c7d88d2ed9a708147bae4e0814a76705e2f",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0266291c7d88d2ed9a708147bae4e0814a76705e2f"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "26",
-            "source": [
-              "2084"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "UNI",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0277cf14f938cb97308d752647d554439d99b39a3f"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200411f06540277cf14f938cb97308d752647d554439d99b39a3f",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0277cf14f938cb97308d752647d554439d99b39a3f"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "22",
-            "source": [
-              "2084"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "SHIB",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x029759ca009cbcd75a84786ac19bb5d02f8e68bcd9"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200411f0654029759ca009cbcd75a84786ac19bb5d02f8e68bcd9",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x029759ca009cbcd75a84786ac19bb5d02f8e68bcd9"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "19",
-            "source": [
-              "2084"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "MATIC",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x02a2a37aaf4730aeedada5aa8ee20a4451cb8b1c4e"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200411f065402a2a37aaf4730aeedada5aa8ee20a4451cb8b1c4e",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x02a2a37aaf4730aeedada5aa8ee20a4451cb8b1c4e"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "20",
-            "source": [
-              "2084"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "LDO",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x02b4ce1f6109854243d1af13b8ea34ed28542f31e0"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200411f065402b4ce1f6109854243d1af13b8ea34ed28542f31e0",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x02b4ce1f6109854243d1af13b8ea34ed28542f31e0"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "18",
-            "source": [
-              "2084"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "ARB",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x02c621abc3afa3f24886ea278fffa7e10e8969d755"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200411f065402c621abc3afa3f24886ea278fffa7e10e8969d755",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x02c621abc3afa3f24886ea278fffa7e10e8969d755"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "17",
-            "source": [
-              "2084"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "BNB",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x02e278651e8ff8e2efa83d7f84205084ebc90688be"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200411f065402e278651e8ff8e2efa83d7f84205084ebc90688be",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x02e278651e8ff8e2efa83d7f84205084ebc90688be"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "21",
-            "source": [
-              "2084"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "WETH",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x02ece0cc38021e734bef1d5da071b027ac2f71181f"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200411f065402ece0cc38021e734bef1d5da071b027ac2f71181f",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x02ece0cc38021e734bef1d5da071b027ac2f71181f"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "27",
-            "source": [
-              "2084"
-            ]
-          },
-          {
-            "paraID": 2004,
-            "relayChain": "kusama",
-            "nativeChainID": "khala",
-            "symbol": "PHA",
-            "decimals": 12,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2004
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010100511f",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2004
-                  }
-                }
-              }
-            },
-            "asset": "13",
-            "source": [
-              "2084"
-            ]
-          },
-          {
-            "paraID": 2023,
-            "relayChain": "kusama",
-            "nativeChainID": "moonriver",
-            "symbol": "MOVR",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2023
-              },
-              {
-                "palletInstance": 10
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x0102009d1f040a",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2023
-                    },
-                    {
-                      "palletInstance": 10
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "11",
-            "source": [
-              "2084"
-            ]
-          }
-        ]
-      },
-      {
-        "relayChain": "kusama",
-        "paraID": 2085,
-        "id": "heiko",
-        "xcAssetCnt": "9",
-        "data": [
-          {
-            "paraID": 0,
-            "relayChain": "kusama",
-            "nativeChainID": "kusama",
-            "symbol": "KSM",
-            "decimals": 12,
-            "interiorType": "here",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              "here"
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "here": null
-                }
-              }
-            },
-            "asset": "100",
-            "source": [
-              "2085"
-            ]
-          },
-          {
-            "paraID": 1000,
-            "relayChain": "kusama",
-            "nativeChainID": "statemine",
-            "symbol": "USDT",
-            "decimals": 6,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 1000
-              },
-              {
-                "palletInstance": 50
-              },
-              {
-                "generalIndex": 1984
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 1000
-                    },
-                    {
-                      "palletInstance": 50
-                    },
-                    {
-                      "generalIndex": 1984
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "102",
-            "source": [
-              "2085"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "LKSM",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0083"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0083"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "109",
-            "source": [
-              "2085"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "KAR",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0080"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0080"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "107",
-            "source": [
-              "2085"
-            ]
-          },
-          {
-            "paraID": 2004,
-            "relayChain": "kusama",
-            "nativeChainID": "khala",
-            "symbol": "PHA",
-            "decimals": 12,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2004
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2004
-                  }
-                }
-              }
-            },
-            "asset": "115",
-            "source": [
-              "2085"
-            ]
-          },
-          {
-            "paraID": 2023,
-            "relayChain": "kusama",
-            "nativeChainID": "moonriver",
-            "symbol": "MOVR",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2023
-              },
-              {
-                "palletInstance": 10
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2023
-                    },
-                    {
-                      "palletInstance": 10
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "113",
-            "source": [
-              "2085"
-            ]
-          },
-          {
-            "paraID": 2085,
-            "relayChain": "kusama",
-            "nativeChainID": "heiko",
-            "symbol": "sKSM",
-            "decimals": 12,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2085
-              },
-              {
-                "palletInstance": 6
-              },
-              {
-                "generalIndex": 1000
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 2085
-                    },
-                    {
-                      "palletInstance": 6
-                    },
-                    {
-                      "generalIndex": 1000
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "1000",
-            "source": [
-              "2085"
-            ]
-          },
-          {
-            "paraID": 2092,
-            "relayChain": "kusama",
-            "nativeChainID": "kintsugi",
-            "symbol": "KBTC",
-            "decimals": 8,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2092
-              },
-              {
-                "generalKey": "0x000b"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2092
-                    },
-                    {
-                      "generalKey": "0x000b"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "121",
-            "source": [
-              "2085"
-            ]
-          },
-          {
-            "paraID": 2092,
-            "relayChain": "kusama",
-            "nativeChainID": "kintsugi",
-            "symbol": "KINT",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2092
-              },
-              {
-                "generalKey": "0x000c"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2092
-                    },
-                    {
-                      "generalKey": "0x000c"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "119",
-            "source": [
-              "2085"
-            ]
-          }
-        ]
-      },
-      {
-        "relayChain": "kusama",
-        "paraID": 2088,
-        "id": "altair",
-        "xcAssetCnt": "4",
-        "data": [
-          {
-            "paraID": 0,
-            "relayChain": "kusama",
-            "nativeChainID": "kusama",
-            "symbol": "KSM",
-            "decimals": 12,
-            "interiorType": "here",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              "here"
-            ],
-            "xcmV1MultiLocationByte": "0x0100",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "here": null
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "3"
-            },
-            "source": [
-              "2088"
-            ]
-          },
-          {
-            "paraID": 1000,
-            "relayChain": "kusama",
-            "nativeChainID": "statemine",
-            "symbol": "USDT",
-            "decimals": 6,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 1000
-              },
-              {
-                "palletInstance": 50
-              },
-              {
-                "generalIndex": 1984
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010300a10f043205011f",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 1000
-                    },
-                    {
-                      "palletInstance": 50
-                    },
-                    {
-                      "generalIndex": 1984
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "1"
-            },
-            "source": [
-              "2088"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "aUSD",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0081"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200411f06080081",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0081"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "2"
-            },
-            "source": [
-              "2088"
-            ]
-          },
-          {
-            "paraID": 2088,
-            "relayChain": "kusama",
-            "nativeChainID": "altair",
-            "symbol": "AIR",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2088
-              },
-              {
-                "generalKey": "0x0001"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200a12006080001",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2088
-                    },
-                    {
-                      "generalKey": "0x0001"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "Native",
-            "source": [
-              "2088"
-            ]
-          }
-        ]
-      },
-      {
-        "relayChain": "kusama",
-        "paraID": 2090,
-        "id": "basilisk",
-        "xcAssetCnt": "10",
-        "data": [
-          {
-            "paraID": 0,
-            "relayChain": "kusama",
-            "nativeChainID": "kusama",
-            "symbol": "KSM",
-            "decimals": 12,
-            "interiorType": "here",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              "here"
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "here": null
-                }
-              }
-            },
-            "asset": "1",
-            "source": [
-              "2090"
-            ]
-          },
-          {
-            "paraID": 1000,
-            "relayChain": "kusama",
-            "nativeChainID": "statemine",
-            "symbol": "USDT",
-            "decimals": 6,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 1000
-              },
-              {
-                "palletInstance": 50
-              },
-              {
-                "generalIndex": 1984
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 1000
-                    },
-                    {
-                      "palletInstance": 50
-                    },
-                    {
-                      "generalIndex": 1984
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "14",
-            "source": [
-              "2090"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "DAI",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x024bb6afb5fa2b07a5d1c499e1c3ddb5a15e709a71"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x024bb6afb5fa2b07a5d1c499e1c3ddb5a15e709a71"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "13",
-            "source": [
-              "2090"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "USDCet",
-            "decimals": 6,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x021f3a10587a20114ea25ba1b388ee2dd4a337ce27"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x021f3a10587a20114ea25ba1b388ee2dd4a337ce27"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "9",
-            "source": [
-              "2090"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "aUSD",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0081"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0081"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "2",
-            "source": [
-              "2090"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "wETH",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x02ece0cc38021e734bef1d5da071b027ac2f71181f"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x02ece0cc38021e734bef1d5da071b027ac2f71181f"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "10",
-            "source": [
-              "2090"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "wBTC",
-            "decimals": 8,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0266291c7d88d2ed9a708147bae4e0814a76705e2f"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0266291c7d88d2ed9a708147bae4e0814a76705e2f"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "11",
-            "source": [
-              "2090"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "wUSDT",
-            "decimals": 6,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0254e183e533fd3c6e72debb2d1cab451d017faf72"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0254e183e533fd3c6e72debb2d1cab451d017faf72"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "12",
-            "source": [
-              "2090"
-            ]
-          },
-          {
-            "paraID": 2048,
-            "relayChain": "kusama",
-            "nativeChainID": "robonomics",
-            "symbol": "XRT",
-            "decimals": 9,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2048
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2048
-                  }
-                }
-              }
-            },
-            "asset": "16",
-            "source": [
-              "2090"
-            ]
-          },
-          {
-            "paraID": 2125,
-            "relayChain": "kusama",
-            "nativeChainID": null,
-            "symbol": "TNKR",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2125
-              },
-              {
-                "generalIndex": 0
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2125
-                    },
-                    {
-                      "generalIndex": 0
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "6",
-            "source": [
-              "2090"
-            ]
-          }
-        ]
-      },
-      {
-        "relayChain": "kusama",
-        "paraID": 2092,
-        "id": "kintsugi",
-        "xcAssetCnt": "6",
-        "data": [
-          {
-            "paraID": 1000,
-            "relayChain": "kusama",
-            "nativeChainID": "statemine",
-            "symbol": "USDT",
-            "decimals": 6,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 1000
-              },
-              {
-                "palletInstance": 50
-              },
-              {
-                "generalIndex": 1984
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 1000
-                    },
-                    {
-                      "palletInstance": 50
-                    },
-                    {
-                      "generalIndex": 1984
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "3"
-            },
-            "source": [
-              "2092"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "AUSD",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0081"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0081"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "1"
-            },
-            "source": [
-              "2092"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "LKSM",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0083"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0083"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "2"
-            },
-            "source": [
-              "2092"
-            ]
-          },
-          {
-            "paraID": 2001,
-            "relayChain": "kusama",
-            "nativeChainID": "bifrost",
-            "symbol": "VKSM",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2001
-              },
-              {
-                "generalKey": "0x0104"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2001
-                    },
-                    {
-                      "generalKey": "0x0104"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "5"
-            },
-            "source": [
-              "2092"
-            ]
-          },
-          {
-            "paraID": 2023,
-            "relayChain": "kusama",
-            "nativeChainID": "moonriver",
-            "symbol": "MOVR",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2023
-              },
-              {
-                "palletInstance": 10
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2023
-                    },
-                    {
-                      "palletInstance": 10
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "4"
-            },
-            "source": [
-              "2092"
-            ]
-          },
-          {
-            "paraID": 2085,
-            "relayChain": "kusama",
-            "nativeChainID": "heiko",
-            "symbol": "SKSM",
-            "decimals": 12,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2085
-              },
-              {
-                "palletInstance": 6
-              },
-              {
-                "generalIndex": 1000
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 2085
-                    },
-                    {
-                      "palletInstance": 6
-                    },
-                    {
-                      "generalIndex": 1000
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": {
-              "ForeignAsset": "6"
-            },
-            "source": [
-              "2092"
-            ]
-          }
-        ]
-      },
-      {
-        "relayChain": "kusama",
-        "paraID": 2110,
-        "id": "mangata",
-        "xcAssetCnt": "9",
-        "data": [
-          {
-            "paraID": 1000,
-            "relayChain": "kusama",
-            "nativeChainID": "statemine",
-            "symbol": "USDT",
-            "decimals": 6,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 1000
-              },
-              {
-                "palletInstance": 50
-              },
-              {
-                "generalIndex": 1984
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010300a10f043205011f",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 1000
-                    },
-                    {
-                      "palletInstance": 50
-                    },
-                    {
-                      "generalIndex": 1984
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "30",
-            "source": [
-              "2110"
-            ]
-          },
-          {
-            "paraID": 1000,
-            "relayChain": "kusama",
-            "nativeChainID": "statemine",
-            "symbol": "RMRK",
-            "decimals": 10,
-            "interiorType": "x3",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 1000
-              },
-              {
-                "palletInstance": 50
-              },
-              {
-                "generalIndex": 8
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010300a10f04320520",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x3": [
-                    {
-                      "parachain": 1000
-                    },
-                    {
-                      "palletInstance": 50
-                    },
-                    {
-                      "generalIndex": 8
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "31",
-            "source": [
-              "2110"
-            ]
-          },
-          {
-            "paraID": 2001,
-            "relayChain": "kusama",
-            "nativeChainID": "bifrost",
-            "symbol": "BNC",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2001
-              },
-              {
-                "generalKey": "0x0001"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200451f06080001",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2001
-                    },
-                    {
-                      "generalKey": "0x0001"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "14",
-            "source": [
-              "2110"
-            ]
-          },
-          {
-            "paraID": 2001,
-            "relayChain": "kusama",
-            "nativeChainID": "bifrost",
-            "symbol": "vBNC",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2001
-              },
-              {
-                "generalKey": "0x0101"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200451f06080101",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2001
-                    },
-                    {
-                      "generalKey": "0x0101"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "23",
-            "source": [
-              "2110"
-            ]
-          },
-          {
-            "paraID": 2001,
-            "relayChain": "kusama",
-            "nativeChainID": "bifrost",
-            "symbol": "vKSM",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2001
-              },
-              {
-                "generalKey": "0x0104"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200451f06080104",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2001
-                    },
-                    {
-                      "generalKey": "0x0104"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "15",
-            "source": [
-              "2110"
-            ]
-          },
-          {
-            "paraID": 2001,
-            "relayChain": "kusama",
-            "nativeChainID": "bifrost",
-            "symbol": "ZLK",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2001
-              },
-              {
-                "generalKey": "0x0207"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200451f06080207",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2001
-                    },
-                    {
-                      "generalKey": "0x0207"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "26",
-            "source": [
-              "2110"
-            ]
-          },
-          {
-            "paraID": 2001,
-            "relayChain": "kusama",
-            "nativeChainID": "bifrost",
-            "symbol": "vsKSM",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2001
-              },
-              {
-                "generalKey": "0x0404"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200451f06080404",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2001
-                    },
-                    {
-                      "generalKey": "0x0404"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "16",
-            "source": [
-              "2110"
-            ]
-          },
-          {
-            "paraID": 2114,
-            "relayChain": "kusama",
-            "nativeChainID": "turing",
-            "symbol": "TUR",
-            "decimals": 10,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2114
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x0101000921",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2114
-                  }
-                }
-              }
-            },
-            "asset": "7",
-            "source": [
-              "2110"
-            ]
-          },
-          {
-            "paraID": 2121,
-            "relayChain": "kusama",
-            "nativeChainID": "imbue",
-            "symbol": "IMBU",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2121
-              },
-              {
-                "generalKey": "0x0096"
-              }
-            ],
-            "xcmV1MultiLocationByte": "0x010200252106080096",
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2121
-                    },
-                    {
-                      "generalKey": "0x0096"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "11",
-            "source": [
-              "2110"
-            ]
-          }
-        ]
-      },
-      {
-        "relayChain": "kusama",
-        "paraID": 2114,
-        "id": "turing",
-        "xcAssetCnt": "10",
-        "data": [
-          {
-            "paraID": 0,
-            "relayChain": "kusama",
-            "nativeChainID": "kusama",
-            "symbol": "KSM",
-            "decimals": 12,
-            "interiorType": "here",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              "here"
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "here": null
-                }
-              }
-            },
-            "asset": "1",
-            "source": [
-              "2114"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "AUSD",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0081"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0081"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "2",
-            "source": [
-              "2114"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "KAR",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0080"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0080"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "3",
-            "source": [
-              "2114"
-            ]
-          },
-          {
-            "paraID": 2000,
-            "relayChain": "kusama",
-            "nativeChainID": "karura",
-            "symbol": "LKSM",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2000
-              },
-              {
-                "generalKey": "0x0083"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2000
-                    },
-                    {
-                      "generalKey": "0x0083"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "4",
-            "source": [
-              "2114"
-            ]
-          },
-          {
-            "paraID": 2004,
-            "relayChain": "kusama",
-            "nativeChainID": "khala",
-            "symbol": "PHA",
-            "decimals": 12,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2004
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2004
-                  }
-                }
-              }
-            },
-            "asset": "7",
-            "source": [
-              "2114"
-            ]
-          },
-          {
-            "paraID": 2007,
-            "relayChain": "kusama",
-            "nativeChainID": "shiden",
-            "symbol": "SDN",
-            "decimals": 18,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2007
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2007
-                  }
-                }
-              }
-            },
-            "asset": "8",
-            "source": [
-              "2114"
-            ]
-          },
-          {
-            "paraID": 2023,
-            "relayChain": "kusama",
-            "nativeChainID": "moonriver",
-            "symbol": "MOVR",
-            "decimals": 18,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2023
-              },
-              {
-                "palletInstance": 10
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2023
-                    },
-                    {
-                      "palletInstance": 10
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "9",
-            "source": [
-              "2114"
-            ]
-          },
-          {
-            "paraID": 2085,
-            "relayChain": "kusama",
-            "nativeChainID": "heiko",
-            "symbol": "HKO",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2085
-              },
-              {
-                "generalKey": "0x484b4f"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2085
-                    },
-                    {
-                      "generalKey": "0x484b4f"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "5",
-            "source": [
-              "2114"
-            ]
-          },
-          {
-            "relayChain": "kusama",
-            "nativeChainID": null,
-            "symbol": "TUR",
-            "decimals": 10,
-            "interiorType": "x1",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2114
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x1": {
-                    "parachain": 2114
-                  }
-                }
-              }
-            },
-            "asset": "0",
-            "source": [
-              "2114"
-            ]
-          },
-          {
-            "paraID": 2085,
-            "relayChain": "kusama",
-            "nativeChainID": "heiko",
-            "symbol": "SKSM",
-            "decimals": 12,
-            "interiorType": "x2",
-            "xcmV1Standardized": [
-              {
-                "network": "kusama"
-              },
-              {
-                "parachain": 2085
-              },
-              {
-                "generalKey": "0x734b534d"
-              }
-            ],
-            "xcmV1MultiLocationByte": false,
-            "xcmV1MultiLocation": {
-              "v1": {
-                "parents": 1,
-                "interior": {
-                  "x2": [
-                    {
-                      "parachain": 2085
-                    },
-                    {
-                      "generalKey": "0x734b534d"
-                    }
-                  ]
-                }
-              }
-            },
-            "asset": "6",
-            "source": [
-              "2114"
-            ]
-          }
-        ]
-      }
-    ]
   }
 }

--- a/src/createRegistry.ts
+++ b/src/createRegistry.ts
@@ -431,8 +431,8 @@ const assignXcAssetsToRelay = (
 ): void => {
 	const chainAssetInfo = xcAssets[chain];
 	for (const paraInfo of chainAssetInfo) {
-		const { paraId } = paraInfo;
-		const para = registry[chain][paraId];
+		const { paraID } = paraInfo;
+		const para = registry[chain][paraID];
 
 		if (para) {
 			const sanitizedData = sanitizeXcAssetData(paraInfo.data);
@@ -444,7 +444,7 @@ const assignXcAssetsToRelay = (
 const sanitizeXcAssetData = (data: XcAssetsData[]): SanitizedXcAssetsData[] => {
 	const mappedData = data.map((info) => {
 		return {
-			paraId: info.paraId,
+			paraID: info.paraID,
 			nativeChainId: info.nativeChainId,
 			symbol: info.symbol,
 			decimals: info.decimals,

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,14 +61,14 @@ export type XcAssets = {
 
 export type XcAssetsInfo = {
 	relayChain: string;
-	paraId: number;
+	paraID: number;
 	id: string;
 	xcAssetCnt: string;
 	data: XcAssetsData[];
 };
 
 export type XcAssetsData = {
-	paraId: number;
+	paraID: number;
 	relayChain: string;
 	nativeChainId: string;
 	symbol: string;
@@ -82,7 +82,7 @@ export type XcAssetsData = {
 };
 
 export type SanitizedXcAssetsData = {
-	paraId: number;
+	paraID: number;
 	nativeChainId: string;
 	symbol: string;
 	decimals: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,20 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
+import type { AnyJson } from '@polkadot/types/types';
+
 export type TokenRegistry = {
-	polkadot: {};
-	kusama: {};
-	westend: {};
+	polkadot: ChainInfo;
+	kusama: ChainInfo;
+	westend: ChainInfo;
+};
+
+export type ChainInfo = {
+	[key: string]: {
+		assetsInfo: AssetsInfo;
+		specName: string;
+		foreignAssetsInfo: ForeignAssetsInfo;
+		poolPairsInfo: PoolPairsInfo;
+	};
 };
 
 export type PoolPairsInfo = {
@@ -42,3 +53,43 @@ export interface PoolInfo {
 export interface ParaIds {
 	[key: string]: number[];
 }
+
+export type XcAssets = {
+	polkadot: XcAssetsInfo[];
+	kusama: XcAssetsInfo[];
+};
+
+export type XcAssetsInfo = {
+	relayChain: string;
+	paraId: number;
+	id: string;
+	xcAssetCnt: string;
+	data: XcAssetsData[];
+};
+
+export type XcAssetsData = {
+	paraId: number;
+	relayChain: string;
+	nativeChainId: string;
+	symbol: string;
+	decimals: number;
+	interiorType: string;
+	xcmV1Standardized: XcAssetXcmStandardized[];
+	xcmV1MultiLocationByte: boolean;
+	xcmV1MultiLocation: AnyJson;
+	asset: { ForeignAsset: string } | string;
+	source: string[];
+};
+
+export type SanitizedXcAssetsData = {
+	paraId: number;
+	nativeChainId: string;
+	symbol: string;
+	decimals: number;
+	xcmV1MultiLocation: string;
+	asset: { ForeignAsset: string } | string;
+};
+
+export type XcAssetXcmStandardized = {
+	[x: string]: string | number;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export type ChainInfo = {
 		specName: string;
 		foreignAssetsInfo: ForeignAssetsInfo;
 		poolPairsInfo: PoolPairsInfo;
+		xcAssetsData?: SanitizedXcAssetsData[];
 	};
 };
 


### PR DESCRIPTION
## Summary

This PR aims to remove the `xcAssets` key from the registry, and instead strip and sanitize the necessary data to be inside of each respective parachain. 

Overall this provides a ~70% reduction in the size of `registry.json` file.