### PR TITLE
ci: change cron job to every 24 hours

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -2,7 +2,7 @@ name: registry
 
 on:
   schedule:
-   - cron: '0 * * * *'
+   - cron: '0 0 * * *'
   
 jobs:
   build-registry:


### PR DESCRIPTION
This is temporary. Currently until: https://github.com/paritytech/asset-transfer-api/pull/327 is officially merged into the `asset-transfer-api` there is no reason to consume resources every hour. 