### PR TITLE
fix: update darwinia chains endpoints

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -25,8 +25,8 @@ export const RPC_BLACK_LIST = [
 	'wss://kreivo.kippu.rocks/',
 	'wss://rpc-karura.luckyfriday.io',
 	'wss://rpc-acala.luckyfriday.io',
-	'wss://crab-rpc.darwiniacommunitydao.xyz',
-	'wss://darwinia-rpc.darwiniacommunitydao.xyz',
+	'wss://crab-rpc.darwinia.network',
+	'wss://rpc.darwinia.network',
 ];
 
 export const DEFAULT_REGISTRY: TokenRegistry = {


### PR DESCRIPTION
The Darwinia support PR merged into the XGR yesterday. https://github.com/colorfulnotion/xcm-global-registry/pull/50. I noticed that this repo also relies on the XGR data, but I did not see the XGR Darwinia data imported into the registry.json under the docs. I guess it may be caused by the outdated endpoint; this PR aims to replace them with valid ones.

![image](https://github.com/user-attachments/assets/e6c8324a-e297-42a9-82f0-d0f6f0444cf5)

