### PR TITLE
feat: add xcAssetsData property with USDC-USDT

### DIFF
--- a/src/createChainRegistryFromParas.ts
+++ b/src/createChainRegistryFromParas.ts
@@ -3,7 +3,7 @@
 import type { EndpointOption } from '@polkadot/apps-config/endpoints/types';
 
 /* eslint-disable-next-line */
-import FinalRegistry from '../docs/registry.json' with { type: 'json' };
+import FinalRegistry from '../docs/registry.json' assert { type: 'json' };
 import { fetchChainInfo } from './fetchChainInfo.js';
 import type {
 	ChainInfoKeys,

--- a/src/fetchChainInfo.ts
+++ b/src/fetchChainInfo.ts
@@ -1,7 +1,9 @@
 // Copyright 2024 Parity Technologies (UK) Ltd.
 
+import { ApiPromise } from '@polkadot/api';
 import { EndpointOption } from '@polkadot/apps-config/endpoints/types.js';
 
+import FinalRegistry from '../docs/registry.json' assert { type: 'json' };
 import { ASSET_HUB_SPEC_NAMES } from './consts.js';
 import { fetchSystemParachainAssetConversionPoolInfo } from './fetchSystemParachainAssetConversionPoolInfo.js';
 import { fetchSystemParachainAssetInfo } from './fetchSystemParachainAssetInfo.js';
@@ -12,6 +14,7 @@ import type {
 	ChainInfoKeys,
 	ForeignAssetsInfo,
 	PoolPairsInfo,
+	SanitizedXcAssetsData,
 } from './types.js';
 import { logWithDate } from './util.js';
 
@@ -58,6 +61,8 @@ export const fetchChainInfo = async (
 			poolPairsInfo = await fetchSystemParachainAssetConversionPoolInfo(api);
 		}
 
+		const xcAssets = await updateChainInfoWithUsdtAsset(api, paraId);
+
 		await api.disconnect();
 
 		return [
@@ -67,10 +72,72 @@ export const fetchChainInfo = async (
 				foreignAssetsInfo,
 				poolPairsInfo,
 				specName: specNameStr,
+				...(xcAssets && xcAssets.length != 0 ? { xcAssetsData: xcAssets } : {}),
 			},
 			endpointOpts.paraId,
 		];
 	} else {
 		return null;
 	}
+};
+
+const updateChainInfoWithUsdtAsset = async (
+	api: ApiPromise,
+	paraId: number,
+): Promise<SanitizedXcAssetsData[] | undefined> => {
+	if (!api?.call?.xcmPaymentApi) return;
+
+	const chainInfoRegistry = FinalRegistry.polkadot[paraId] as ChainInfoKeys;
+
+	// Check if USDT or USDC are already in xcAssetsData
+	if (
+		chainInfoRegistry?.xcAssetsData?.some((item) =>
+			/usdt|usdc/i.test(item.symbol),
+		)
+	) {
+		return;
+	}
+
+	// USDT Location
+	const usdtXcmPath =
+		'{"v3":{"concrete":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":1984}]}}}}';
+	// USDC Location
+	const usdcXcmPath =
+		'{"v3":{"concrete":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":1337}]}}}}';
+
+	const xcAssets: SanitizedXcAssetsData[] = [];
+	// Check acceptable payment assets
+	try {
+		const paymentAssetsV3 =
+			await api.call.xcmPaymentApi.queryAcceptablePaymentAssets(3);
+		const paymentAssetsJson = JSON.parse(JSON.stringify(paymentAssetsV3)) as {
+			ok: string[];
+		};
+		const assetDict: Record<string, string> = {
+			[usdtXcmPath]: 'USDT',
+			[usdcXcmPath]: 'USDC',
+		};
+		// Check if USDT or USDC are one of the acceptable payment assets
+		for (const item of paymentAssetsJson.ok) {
+			if (
+				JSON.stringify(item) == usdtXcmPath ||
+				JSON.stringify(item) == usdcXcmPath
+			) {
+				xcAssets.push({
+					paraID: paraId,
+					nativeChainID: 'asset-hub-polkadot',
+					symbol: assetDict[JSON.stringify(item)],
+					decimals: 6,
+					xcmV1MultiLocation: usdcXcmPath,
+					assetHubReserveLocation: '{"parents":"0","interior":{"Here":""}}',
+				} as SanitizedXcAssetsData);
+			}
+		}
+	} catch (error) {
+		console.error(
+			`Error fetching XCM payment assets for paraId ${paraId}:`,
+			error,
+		);
+	}
+	return xcAssets;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable-next-line */
-import REGISTRY from '../docs/registry.json' with { type: 'json' };
+import REGISTRY from '../docs/registry.json' assert { type: 'json' };
 import { PROD_REGISTRY_FILE_PATH } from './consts.js';
 import { main } from './createRegistry.js';
 import type { TokenRegistry } from './types.js';


### PR DESCRIPTION
### Description
This PR wishes to resolve the issue [#544](https://github.com/paritytech/asset-transfer-api/issues/544) in `asset-transfer-api` (check the root cause in the relevant section of that issue).

### Suggested Solution
In [fetchChainInfo](https://github.com/paritytech/asset-transfer-api-registry/blob/main/src/fetchChainInfo.ts#L60) check also a parachain's acceptable payment assets. If any of those acceptable assets are `USDT` or `USDC`, add them in the registry under the key `xcAssetsData` of the current parachain Id.

### Implementation Notes
Some important notes to keep in mind while reviewing this code:
- It checks **only** for the `USDT` and `USDC` assets.
- The locations of these assets are hard coded which is not ideal. The reason is to avoid any extra calls to AH to get these locations and since these locations are standard/should not change.
- These locations are added only if the property `xcAssetsData` does not exist at all in the registry under the `paraId` that is checked.
- I use `xcmPaymentApi.queryAcceptablePaymentAssets` with XCM v3. I could have used v4 but I used v3 with no strong arguments to support it. If there is an objection on this please let know.
- If `xcAssetsData` property exists, it will not update it. 
    - ⚠️ This means that if `xcAssetsData` property exists and it does not include `USDC` or `USDT` it will not add them. This is very correct but I had some issues in updating an already existing `xcAssetsData` property. Any suggestions to resolve this are welcome or maybe in a follow up PR. 

### How to Test
asset-transfer-api-registry
- git clone the current repository
- check out in the current branch
- yarn start
- it will update the registry (file `docs/registry.json`) and add the `xcAssetsData` property with the assets `USDT` and `USDC` under the Polimec parachain under Polkadot relay.

asset-transfer-api
- go back in the parent folder
- git clone [asset-transfer-api](https://github.com/paritytech/asset-transfer-api)
- checkout in the branch of this PR [#546](https://github.com/paritytech/asset-transfer-api/pull/546)
- update the `package.json` so that it points to the local `asset-transfer-api-registry` (cloned previously). It should look something like this:
  ```
  "@substrate/asset-transfer-api-registry": "file:../asset-transfer-api-registry"
  ```
- `yarn install`
- `yarn build`

demo code
- go back in the parent folder
- mkdir `asset-transfer-api-demo`
- cd `asset-transfer-api-demo`
- `npm init`
- `npm install @substrate/asset-transfer-api`
- update the `package.json` so that it points to your local `asset-transfer-api` (cloned previously). It should look something like this:
  ```
    "dependencies": {
    "@substrate/asset-transfer-api": "file:../asset-transfer-api"
    }
  ```
- `rm -rf node_modules package-lock.json`
- `npm install`
- `touch main.js` and paste the following code
    ```
    const { AssetTransferApi, constructApiPromise } = require('../asset-transfer-api'); 
    
    const main = async () => {
    
        const { api, specName, safeXcmVersion } = await constructApiPromise('wss://polkadot-asset-hub-rpc.polkadot.io');
    
        const assetTransferApi = new AssetTransferApi(api, specName, safeXcmVersion);
    
        const sendersAddr = '16FNntR3F4ZjsTdYHysWSiP2vGHoVL7uZ9tyfyd4o5Cdaghf';
        const tx = '0x1f0b04010100c91f0400010100e823f55dbee3d394f448f2f74194078ba4259e4b31c28e155c29531106a8ea0804080002043205011f0002093d000100000700e40b54020000000000';
        const dryRunResult = await assetTransferApi.dryRunCall(sendersAddr, tx, 'call');
    
        const destinationFees = await AssetTransferApi.getDestinationXcmWeightToFeeAsset(
          'polimec-mainnet',
          'wss://rpc.polimec.org',
          4,
          dryRunResult,
          'USDT'
        );
        console.log('payload', JSON.stringify(destinationFees));
    }
    main();
    ```
- in the above code make sure to point to your local `../asset-transfer-api` folder
- `node main.js` to run the demo code

This should return a fee for the `Polimec` chain and `USDT`. This is exactly what is currently not working in [#544](https://github.com/paritytech/asset-transfer-api/issues/544) issue.

### Credits
Credits to @TarikGul and @franciscoaguirre for the suggestions and advice relevant to this issue.