### PR TITLE
docs: Update README with a deprecation notice (if we decide to deprecate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+⚠️**Deprecated**⚠️: `asset-transfer-api` and `asset-transfer-api-registry` been deprecated and are no longer actively maintained.
+
+Please use [✨ParaSpell✨](https://paraspell.github.io/docs/) instead. The ParaSpell asset registry can be found [here](https://github.com/paraspell/xcm-tools/blob/main/packages/assets/src/maps/assets.json) or accessed directly as [a packaged via npm](https://www.npmjs.com/package/@paraspell/assets).
+
+Additional information can be found in [this GitHub issue](https://github.com/paritytech/asset-transfer-api/issues/652).
+
 <br /><br />
 
 <div align="center">


### PR DESCRIPTION
Related to https://github.com/paritytech/asset-transfer-api/issues/652.

Staging as a draft for now so this is ready if/when `asset-transfer-api` is deprecated.

[Quick link to rendered README](https://github.com/paritytech/asset-transfer-api-registry/tree/docs/deprecation)