### PR TITLE
fix: Exit with exit code 1 when there is an error.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,13 @@ import { PROD_REGISTRY_FILE_PATH } from './consts.js';
 import { main } from './createRegistry.js';
 import type { TokenRegistry } from './types.js';
 
-main(PROD_REGISTRY_FILE_PATH, REGISTRY as unknown as TokenRegistry)
-	.catch((err) => console.error(err))
-	.finally(() => process.exit());
+void (async () => {
+	try {
+		await main(PROD_REGISTRY_FILE_PATH, REGISTRY as unknown as TokenRegistry);
+	} catch (err) {
+		console.error(err);
+		process.exit(1);
+	} finally {
+		process.exit();
+	}
+})();


### PR DESCRIPTION
The scheduled job has been repeatedly failing in silence due to the removal of https://github.com/colorfulnotion/xcm-global-registry and https://cdn.jsdelivr.net/gh/colorfulnotion/xcm-global-registry/metadata/xcmgar.json but this was going uncaught.

[Example of silent failure](https://github.com/paritytech/asset-transfer-api-registry/actions/runs/16924063742/job/47956241519#step:5:62625)